### PR TITLE
Se agregó el metodo last_sql_query

### DIFF
--- a/core/libs/db/adapters/firebird.php
+++ b/core/libs/db/adapters/firebird.php
@@ -522,4 +522,14 @@ class DbFirebird extends DbBase implements DbBaseInterface
         }
     }
 
+    /**
+     * Devuelve la ultima sentencia sql ejecutada por el Adaptador
+     * 
+     * @return string
+     */
+    public function last_sql_query()
+    {
+        return $this->last_query;
+    }
+
 }

--- a/core/libs/db/adapters/informix.php
+++ b/core/libs/db/adapters/informix.php
@@ -680,4 +680,14 @@ class DbInformix extends DbBase implements DbBaseInterface
         return $this->query("COMMIT");
     }
 
+    /**
+     * Devuelve la ultima sentencia sql ejecutada por el Adaptador
+     *
+     * @return string
+     */
+    public function last_sql_query()
+    {
+        return $this->last_query;
+    }
+
 }

--- a/core/libs/db/adapters/mysql.php
+++ b/core/libs/db/adapters/mysql.php
@@ -523,4 +523,14 @@ class DbMySQL extends DbBase implements DbBaseInterface
         return mysql_fetch_object($result_query, $class);
     }
 
+    /**
+     * Devuelve la ultima sentencia sql ejecutada por el Adaptador
+     *
+     * @return string
+     */
+    public function last_sql_query()
+    {
+        return $this->last_query;
+    }
+
 }

--- a/core/libs/db/adapters/mysqli.php
+++ b/core/libs/db/adapters/mysqli.php
@@ -491,4 +491,14 @@ class DbMySQLi extends DbBase implements DbBaseInterface
         }
     }
 
+    /**
+     * Devuelve la ultima sentencia sql ejecutada por el Adaptador
+     *
+     * @return string
+     */
+    public function last_sql_query()
+    {
+        return $this->last_query;
+    }
+
 }

--- a/core/libs/db/adapters/oracle.php
+++ b/core/libs/db/adapters/oracle.php
@@ -611,6 +611,14 @@ class DbOracle extends DbBase implements DbBaseInterface
         return true;
     }
 
-}
+    /**
+     * Devuelve la ultima sentencia sql ejecutada por el Adaptador
+     *
+     * @return string
+     */
+    public function last_sql_query()
+    {
+        return $this->last_query;
+    }
 
-?>
+}

--- a/core/libs/db/adapters/pdo.php
+++ b/core/libs/db/adapters/pdo.php
@@ -461,4 +461,14 @@ abstract class DbPDO extends DbBase implements DbPDOInterface
         }
     }
 
+    /**
+     * Devuelve la ultima sentencia sql ejecutada por el Adaptador
+     *
+     * @return string
+     */
+    public function last_sql_query()
+    {
+        return $this->last_query;
+    }
+
 }

--- a/core/libs/db/adapters/pgsql.php
+++ b/core/libs/db/adapters/pgsql.php
@@ -550,4 +550,14 @@ class DbPgSQL extends DbBase implements DbBaseInterface
         return pg_fetch_object($queryResult, null, $class);
     }
 
+    /**
+     * Devuelve la ultima sentencia sql ejecutada por el Adaptador
+     *
+     * @return string
+     */
+    public function last_sql_query()
+    {
+        return $this->last_query;
+    }
+
 }

--- a/core/libs/db/adapters/sqlite.php
+++ b/core/libs/db/adapters/sqlite.php
@@ -447,4 +447,14 @@ class DbSQLite extends DbBase implements DbBaseInterface
         return $fields;
     }
 
+    /**
+     * Devuelve la ultima sentencia sql ejecutada por el Adaptador
+     *
+     * @return string
+     */
+    public function last_sql_query()
+    {
+        return $this->last_query;
+    }
+
 }

--- a/core/libs/db/db_base.php
+++ b/core/libs/db/db_base.php
@@ -47,6 +47,12 @@ class DbBase
      * @var mixed
      */
     public $logger = false;
+    /**
+     * Última sentencia SQL enviada al Adaptador
+     *
+     * @var string
+     */
+    private $last_query;
 
     /**
      * Hace un select de una forma mas corta, listo para usar en un foreach


### PR DESCRIPTION
Se agregó este metodo debido a que todos los adaptadores tienen
una variable privada $last_query, y no existe un metodo para
obtener su valor, asi que estaba sin uso en los mismos.

con este metodo se puede obtener el ultimo query ejecutado, lo cual es
importante por ejemplo para llevar una auditoria con los cambios hechos
por los usuarios de una App:

Ejemplo de obtencion: Db::factory()->last_sql_query();
Ó desde un modelo: $usuarios->db->last_sql_query();
