### PR TITLE
corregido bug en select y dbSelect

### DIFF
--- a/core/extensions/helpers/ajax.php
+++ b/core/extensions/helpers/ajax.php
@@ -120,7 +120,7 @@ class Ajax
         }
 
         // ruta a la accion
-        $action = PUBLIC_PATH . rtrim($action, '/') . '/';
+        $action = PUBLIC_PATH . ($action ? rtrim($action, '/') . '/' : '');
 
         // genera el campo
         return Form::select($field, $data, "class=\"js-remote $class\" data-update=\"$update\" data-action=\"$action\" $attrs");
@@ -130,25 +130,25 @@ class Ajax
      * Lista desplegable para actualizar usando ajax que toma los valores de un array de objetos
      *
      * @param string $field nombre de campo
-     * @param array $data Array('modelo','metodo','param')
-     * @param string $show campo que se mostrara
+     * @param string $show campo que se mostrará
+     * @param array  $data Array('modelo','metodo','param')
      * @param string $update capa que se actualizara
      * @param string $action accion que se ejecutara
      * @param string $blank campo en blanco
      * @param string $class
      * @param string|array $attrs
      */
-    public static function dbSelect($field, $data, $show, $update, $action, $blank=null, $class=null, $attrs=null)
+    public static function dbSelect($field, $show, $data, $update, $action, $blank=null, $class=null, $attrs=null)
     {
         if (is_array($attrs)) {
             $attrs = Tag::getAttrs($attrs);
         }
 
         // ruta a la accion
-        $action = PUBLIC_PATH . rtrim($action, '/') . '/';
+        $action = PUBLIC_PATH . ($action ? rtrim($action, '/') . '/' : '');
 
         // genera el campo
-        return Form::dbSelect($field, $data, $show, $blank, "class=\"js-remote $class\" data-update=\"$update\" data-action=\"$action\" $attrs");
+        return Form::dbSelect($field, $show, $data, $blank, "class=\"js-remote $class\" data-update=\"$update\" data-action=\"$action\" $attrs");
     }
 
     /**


### PR DESCRIPTION
fallaba cuando el campo action era vacio ó nulo porque ponia un / al final

y ya el PUBLIC_PATH lo tiene por lo que quedaba con 2 al final.

---

cambio en los nombres de los parametros

Se cambio el nombre de los parametros para que no genere confusion
Ya que el segundo parametro es el campo que se va a mostrar
y el tercero el array con la data para el modelo / metodo / parametros
