### PR TITLE
Adaptando al nuevo router y a la eliminación del dispatcher

### DIFF
--- a/core/extensions/helpers/tags.php
+++ b/core/extensions/helpers/tags.php
@@ -664,13 +664,7 @@ function get_value_from_action($name){
 			return null;
 		}
 	} else {
-		$controller = Dispatcher::get_controller();
-		
-		if(isset($controller->$name)){
-			return $controller->$name;
-		} else {
-			return null;
-		}
+		return View::getVar($name);
 	}
 }
 

--- a/core/libs/kumbia_active_record/kumbia_active_record.php
+++ b/core/libs/kumbia_active_record/kumbia_active_record.php
@@ -1227,11 +1227,7 @@ class KumbiaActiveRecord
         if (!$form) {
             $form = $this->source;
         }
-        $result = $this->create($_REQUEST[$form]);
-        if (!$result) {
-            Dispatcher::get_controller()->$form = $_REQUEST[$form];
-        }
-        return $result;
+        return $this->create($_REQUEST[$form]);
     }
 
     /**
@@ -1245,11 +1241,7 @@ class KumbiaActiveRecord
         if (!$form) {
             $form = $this->source;
         }
-        $result = $this->save($_REQUEST[$form]);
-        if (!$result) {
-            Dispatcher::get_controller()->$form = $_REQUEST[$form];
-        }
-        return $result;
+        return $this->save($_REQUEST[$form]);
     }
 
     /**
@@ -1263,11 +1255,7 @@ class KumbiaActiveRecord
         if (!$form) {
             $form = $this->source;
         }
-        $result = $this->update($_REQUEST[$form]);
-        if (!$result) {
-            Dispatcher::get_controller()->$form = $_REQUEST[$form];
-        }
-        return $result;
+        return $this->update($_REQUEST[$form]);
     }
 
     /**


### PR DESCRIPTION
Se cambian los Dispatcher::get_controller(); que quedaban
para usar el View::getVar()

y se quita el repoblado del form en los *_from_request()
ya que ahora el form se autocarga automaticamente con el $_POST

( aunque si es por get no se autocargará )
