### PR TITLE
mejoras en el active record y las asociaciones

### DIFF
--- a/core/libs/kumbia_active_record/kumbia_active_record.php
+++ b/core/libs/kumbia_active_record/kumbia_active_record.php
@@ -2228,10 +2228,12 @@ class KumbiaActiveRecord
         $params = Util::getParams(func_get_args());
         for ($i = 0; isset($params[$i]); $i++) {
             $relation = Util::uncamelize($params[$i]);
-            if (!array_key_exists($relation, $this->_has_one)) {
-                $this->_has_one[$relation] = new stdClass();
-                $this->_has_one[$relation]->model = isset($params['model']) ? $params['model'] : $relation;
-                $this->_has_one[$relation]->fk = isset($params['fk']) ? $params['fk'] : Util::uncamelize(get_class($this)) . '_id';
+            $index = explode('/', $relation); 
+            $index = end($index);
+            if (!array_key_exists($index, $this->_has_one)) {
+                $this->_has_one[$index] = new stdClass();
+                $this->_has_one[$index]->model = isset($params['model']) ? $params['model'] : $relation;
+                $this->_has_one[$index]->fk = isset($params['fk']) ? $params['fk'] : Util::uncamelize(get_class($this)) . '_id';
             }
         }
     }
@@ -2249,10 +2251,12 @@ class KumbiaActiveRecord
         $params = Util::getParams(func_get_args());
         for ($i = 0; isset($params[$i]); $i++) {
             $relation = Util::uncamelize($params[$i]);
-            if (!array_key_exists($relation, $this->_belongs_to)) {
-                $this->_belongs_to[$relation] = new stdClass();
-                $this->_belongs_to[$relation]->model = isset($params['model']) ? $params['model'] : $relation;
-                $this->_belongs_to[$relation]->fk = isset($params['fk']) ? $params['fk'] : "{$relation}_id";
+            $index = explode('/', $relation); 
+            $index = end($index);
+            if (!array_key_exists($index, $this->_belongs_to)) {
+                $this->_belongs_to[$index] = new stdClass();
+                $this->_belongs_to[$index]->model = isset($params['model']) ? $params['model'] : $relation;
+                $this->_belongs_to[$index]->fk = isset($params['fk']) ? $params['fk'] : "{$relation}_id";
             }
         }
     }
@@ -2270,10 +2274,12 @@ class KumbiaActiveRecord
         $params = Util::getParams(func_get_args());
         for ($i = 0; isset($params[$i]); $i++) {
             $relation = Util::uncamelize($params[$i]);
-            if (!array_key_exists($relation, $this->_has_many)) {
-                $this->_has_many[$relation] = new stdClass();
-                $this->_has_many[$relation]->model = isset($params['model']) ? $params['model'] : $relation;
-                $this->_has_many[$relation]->fk = isset($params['fk']) ? $params['fk'] : Util::uncamelize(get_class($this)) . '_id';
+            $index = explode('/', $relation); 
+            $index = end($index);
+            if (!array_key_exists($index, $this->_has_many)) {
+                $this->_has_many[$index] = new stdClass();
+                $this->_has_many[$index]->model = isset($params['model']) ? $params['model'] : $relation;
+                $this->_has_many[$index]->fk = isset($params['fk']) ? $params['fk'] : Util::uncamelize(get_class($this)) . '_id';
             }
         }
     }


### PR DESCRIPTION
los metodos __get y __call tenian mucho codigo repetido,
se creo una funcion con ese código y se mejoró, ya que antes no
se trabajaba con esquemas en las asociaciones has_and_belongs_to_many
ahora si se buscan y se usan los esquemas de los modelos (de existir dichos esquemas).
para el caso del modelo que hace de through, el esquema debe ser definido
en el modelo donde se especifica la asociacion, ejemplo:

$this->has_and_belongs_to_many('roles','through: admin.roles_usuarios');

admin sería el esquema.

con este cambio se aligera un poco la clase.
