### PR TITLE
Se agrega un namespace a la sesión que maneja la lib Auth

### DIFF
--- a/core/libs/auth/auth.php
+++ b/core/libs/auth/auth.php
@@ -164,9 +164,9 @@ class Auth
                 sleep($this->sleep_time);
             }
         }
-        $_SESSION['KUMBIA_AUTH_IDENTITY'] = $this->adapter_object->get_identity();
+        $_SESSION['KUMBIA_AUTH_IDENTITY'][Config::get('config.application.namespace_auth')] = $this->adapter_object->get_identity();
         self::$active_identity = $this->adapter_object->get_identity();
-        $_SESSION['KUMBIA_AUTH_VALID'] = $result;
+        $_SESSION['KUMBIA_AUTH_VALID'][Config::get('config.application.namespace_auth')] = $result;
         self::$is_valid = $result;
         return $result;
     }
@@ -267,7 +267,7 @@ class Auth
         if (!is_null(self::$is_valid)) {
             return self::$is_valid;
         } else {
-            self::$is_valid = isset($_SESSION['KUMBIA_AUTH_VALID']) ? $_SESSION['KUMBIA_AUTH_VALID'] : null;
+            self::$is_valid = isset($_SESSION['KUMBIA_AUTH_VALID'][Config::get('config.application.namespace_auth')]) ? $_SESSION['KUMBIA_AUTH_VALID'][Config::get('config.application.namespace_auth')] : null;
             return self::$is_valid;
         }
     }
@@ -282,7 +282,7 @@ class Auth
         if (count(self::$active_identity)) {
             return self::$active_identity;
         } else {
-            self::$active_identity = $_SESSION['KUMBIA_AUTH_IDENTITY'];
+            self::$active_identity = $_SESSION['KUMBIA_AUTH_IDENTITY'][Config::get('config.application.namespace_auth')];
             return self::$active_identity;
         }
     }
@@ -296,7 +296,7 @@ class Auth
     public static function get($var = null)
     {
         if ($var) {
-            return $_SESSION['KUMBIA_AUTH_IDENTITY'][$var];
+            return $_SESSION['KUMBIA_AUTH_IDENTITY'][Config::get('config.application.namespace_auth')][$var];
         }
     }
 
@@ -307,9 +307,9 @@ class Auth
     static public function destroy_identity()
     {
         self::$is_valid = null;
-        unset($_SESSION['KUMBIA_AUTH_VALID']);
+        unset($_SESSION['KUMBIA_AUTH_VALID'][Config::get('config.application.namespace_auth')]);
         self::$active_identity = null;
-        unset($_SESSION['KUMBIA_AUTH_IDENTITY']);
+        unset($_SESSION['KUMBIA_AUTH_IDENTITY'][Config::get('config.application.namespace_auth')]);
     }
 
 }

--- a/default/app/config/config.ini
+++ b/default/app/config/config.ini
@@ -32,5 +32,6 @@ log_exceptions = On
 charset = UTF-8
 cache_driver = file
 metadata_lifetime = "+1 year"
+namespace_auth = "default"
 ;locale = es_ES
 ;routes = On


### PR DESCRIPTION
Con este namespace se pueden tener varias apps usando la misma
sesion activa, y ademas pueden haber apps con sesiones diferentes.

Muy util cuando tenemos varias aplicaciones en un mismo servidor.
