### PR TITLE
Defaults active record

### DIFF
--- a/core/libs/kumbia_active_record/kumbia_active_record.php
+++ b/core/libs/kumbia_active_record/kumbia_active_record.php
@@ -1719,7 +1719,7 @@ class KumbiaActiveRecord
                         unset($this->$field);
                     }
 
-                    if (isset($this->$field) && $this->$field != '') {
+                    if (isset($this->$field) && $this->$field !== '' && $this->$field !== NULL) {
                         $fields[] = ActiveRecord::sql_sanizite($field);
 
                         if (($this->_data_type[$field] == 'datetime' || $this->_data_type[$field] == 'date') && $config['type'] == 'mysql') {


### PR DESCRIPTION
ahora los campos con valores default, al hacer un insert, si el
valor pasado a dicho campo es nulo, igual se envia en los arreglos $fields
y $values.

donde $fields será el nombre del campo,
y el valor la palabra reservada DEFAULT.

OJO: solo se ha probado en mysql y postgres.

Este cambio se hace debido a que si se intenta hacer un save, (al menos en postgres) sin pasar ningun dato en ningun momento al modelo, ejemplo  Load::model('modelo')->save();

intentará hacer una consulta como la siguiente: INSERT INTO modelo () values ();

y dará un error de SQL en postgres.
