### PR TITLE
Cambios en la Lib REST.

### DIFF
--- a/core/libs/rest/rest.php
+++ b/core/libs/rest/rest.php
@@ -41,49 +41,53 @@ class Rest
     /**
      * Array con los tipos de datos soportados para salida
      */
-    private static $outputFormat = array('json', 'text', 'html', 'xml', 'cvs', 'php');
+    private static $_outputFormat = array('json', 'text', 'html', 'xml', 'cvs', 'php');
     /**
      * Tipo de datos soportados para entrada
      */
-    private static $inputFormat = array('json', 'plain', 'x-www-form-urlencoded');
+    private static $_inputFormat = array('json', 'plain', 'x-www-form-urlencoded');
     /**
      * Metodo de petición (GET, POST, PUT, DELETE)
      */
-    private static $method = null;
+    private static $_method = null;
     /**
      * Establece el formato de salida
      */
-    private static $oFormat = null;
+    private static $_oFormat = null;
     /**
      * Establece el formato de entrada
      */
-    private static $iFormat = null;
+    private static $_iFormat = null;
 
     /**
      * Establece los tipos de respuesta aceptados
+     * 
+     * @param string $acceptcada uno de los tipos separados por coma ','
      */
     static public function accept($accept)
     {
-        self::$outputFormat = is_array($accept) ? $accept : explode(',', $accept);
+        self::$_outputFormat = is_array($accept) ? $accept : explode(',', $accept);
     }
 
     /**
      * Define el inicio de un servicio REST
+     * 
+     * @param Controller $controller controlador que se convertira en un servicio REST
      */
-    static public function init()
+    static public function init(Controller $controller)
     {
         $content = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : 'text/html';
         /**
          * Verifico el formato de entrada
          */
-        self::$iFormat = str_replace(array('text/', 'application/'), '', $content);
+        self::$_iFormat = str_replace(array('text/', 'application/'), '', $content);
 
         /* Compruebo el método de petición */
-        self::$method = strtolower($_SERVER['REQUEST_METHOD']);
+        self::$_method = strtolower($_SERVER['REQUEST_METHOD']);
         $format = explode(',', $_SERVER['HTTP_ACCEPT']);
-        while (self::$oFormat = array_shift($format)) {
-            self::$oFormat = str_replace(array('text/', 'application/'), '', self::$oFormat);
-            if (in_array(self::$oFormat, self::$outputFormat)) {
+        while (self::$_oFormat = array_shift($format)) {
+            self::$_oFormat = str_replace(array('text/', 'application/'), '', self::$_oFormat);
+            if (in_array(self::$_oFormat, self::$_outputFormat)) {
                 break;
             }
         }
@@ -91,13 +95,30 @@ class Rest
         /**
          * Si no lo encuentro, revuelvo un error
          */
-        if (self::$oFormat == null) {
+        if (self::$_oFormat == null) {
             return 'error';
         } else {
-            View::response(self::$oFormat);
+            View::response(self::$_oFormat);
             View::select('response');
-            return self::$method;
         }
+
+        /**
+         * Si la acción del controlador es un numero lo pasamos a los parametros
+         */
+        if ( is_numeric($controller->action_name) ){
+            $controller->parameters = array($controller->action_name) + Rest::param();
+        }else{
+            $controller->parameters = Rest::param();
+        }
+
+        /**
+         * reescribimos la acción a ejecutar, ahora tendra será el metodo de
+         * la peticion: get , put, post, delete, etc.
+         */
+        $controller->action_name = self::$_method;
+        $controller->limit_params = FALSE; //no hay verificación en el numero de parametros.
+        $controller->data = array(); //variable por defecto para las vistas.
+
     }
 
     /**
@@ -107,7 +128,7 @@ class Rest
     static function param()
     {
         $input = file_get_contents('php://input');
-        if (strncmp(self::$iFormat, 'json', 4) == 0) {
+        if (strncmp(self::$_iFormat, 'json', 4) == 0) {
             return json_decode($input, true);
         } else {
             parse_str($input, $output);


### PR DESCRIPTION
Para simplificarle el trabajo al programador, se pasan las tareas
de reescribir el nombre del action_name, setear el atributo
parameters y limit_params a false, hacia dentro del metodo
Rest::init();

Ahora solo es necesario llamar a Rest::init() y pasarle como parametro
el controlador actual, ejemplo:

class RestController extends AppController{

```
protected function before_filter(){
    Rest::init($this);
    //con esto ya nuestro controlador se ha convertido
    //en un servicio rest.
}
```

}
