### PR TITLE
cambio en el bootstrap.php del core para que carge siempre al de app

### DIFF
--- a/core/kumbia/bootstrap.php
+++ b/core/kumbia/bootstrap.php
@@ -139,6 +139,10 @@ require_once APP_PATH . 'libs/app_controller.php';
 // @see KumbiaView
 require_once APP_PATH . 'libs/view.php';
 
+//Cargamos el bootstrap de app para ejecutar las configuraciones adicionales
+//para cada Aplicación.
+require_once APP_PATH . 'libs/bootstrap.php';
+
 // Ejecuta el request
 try {
     // Dispatch y renderiza la vista

--- a/default/app/libs/bootstrap.php
+++ b/default/app/libs/bootstrap.php
@@ -1,7 +1,2 @@
 <?php
 // Bootstrap de la aplicacion para personalizarlo
-// Para cargar cambia en public/index.php el require del bootstrap a app
-
-// Arranca KumbiaPHP
-require_once CORE_PATH . 'kumbia/bootstrap.php';
-

--- a/default/public/index.php
+++ b/default/public/index.php
@@ -73,9 +73,7 @@ $url = isset($_GET['_url']) ? $_GET['_url'] : '/';
 
 /**
  * Carga el gestor de arranque
- * Por defecto el bootstrap del core
  *
  * @see Bootstrap
  */
-//require APP_PATH . 'libs/bootstrap.php'; //bootstrap de app
 require CORE_PATH . 'kumbia/bootstrap.php'; //bootstrap del core 


### PR DESCRIPTION
Con este cambio, el programador podrá justo antes de que el boottrap del core llame al dispatcher
ejecutar configuraciones adicionales necesarias en cada aplicación, como gettext, canbiar configuraciones del php.ini, etc.
