### PR TITLE
Cambio en el formato del nombre en los archivos logs

### DIFF
--- a/core/libs/logger/logger.php
+++ b/core/libs/logger/logger.php
@@ -92,7 +92,7 @@ abstract class Logger
     {
         self::$log_path = APP_PATH . 'temp/logs/';
         if ($name === '' || $name === true) {
-            $name = 'log' . date('dmY') . '.txt';
+            $name = 'log' . date('Y-m-d') . '.txt';
         }
         self::$fileLogger = fopen(self::$log_path . $name, 'a');
         if (!self::$fileLogger) {


### PR DESCRIPTION
 Se cambia el formato del nombre de los logs para facilitar una mejor lectura de archivos, pues se puede hacer una interfaz en un backend para la lectura de los mismos
