### PR TITLE
Modificación del PUBLIC_PATH

### DIFF
--- a/default/public/index.php
+++ b/default/public/index.php
@@ -61,7 +61,7 @@ define('CORE_PATH', dirname(dirname(APP_PATH)) . '/core/');
  *   cliente (con el navegador web) y es relativa al DOCUMENT_ROOT del servidor web
  */
 if ($_SERVER['QUERY_STRING']) {
-    define('PUBLIC_PATH', substr(urldecode($_SERVER['REQUEST_URI']), 0, - strlen($_SERVER['QUERY_STRING']) + 6));
+    define('PUBLIC_PATH', substr(urldecode($_SERVER['REQUEST_URI']), 0, - strlen(urldecode($_SERVER['QUERY_STRING'])) + 6));
 } else {
     define('PUBLIC_PATH', $_SERVER['REQUEST_URI']);
 }


### PR DESCRIPTION
Arreglado PUBLIC_PATH. Se calculaba mal el tamaño a recortar cuando la URL tenía caracteres tipo %##. 
