### PR TITLE
Ahora el template por default se especifica desde config.ini

### DIFF
--- a/core/kumbia/bootstrap.php
+++ b/core/kumbia/bootstrap.php
@@ -62,6 +62,10 @@ $config = Config::read('config');
 if (!defined('PRODUCTION')) {
     define('PRODUCTION', $config['application']['production']);
 }
+//Constante que indica cual sera el tamplate por default a usar
+if (!defined('TEMPLATE')) {
+    define('TEMPLATE', $config['application']['template']);
+}
 
 // Carga la cache y verifica si esta cacheado el template, al estar en produccion
 if (PRODUCTION) {

--- a/core/kumbia/kumbia_view.php
+++ b/core/kumbia/kumbia_view.php
@@ -44,7 +44,7 @@ class KumbiaView
      *
      * @var string
      */
-    protected static $_template = 'default';
+    protected static $_template = TEMPLATE;
     /**
      * Indica el tipo de salida generada por el controlador
      *
@@ -216,6 +216,7 @@ class KumbiaView
 
             // Renderizar vista
             ob_start();
+
 
             $__file = APP_PATH . 'views/' . self::getPath();
             //Si no existe el view y es scaffold

--- a/default/app/config/config.ini
+++ b/default/app/config/config.ini
@@ -33,5 +33,6 @@ charset = UTF-8
 cache_driver = file
 metadata_lifetime = "+1 year"
 namespace_auth = "default"
+template = default
 ;locale = es_ES
 ;routes = On


### PR DESCRIPTION
esto para cuando se requiere actualizar un nuevo template, 
por ejemplo rediseño, y si esta el codigo en algun repositorio sera muy tedioso el renombrar carpetas
para poner el nuevo diseño en la carpeta default, en vez de esto y de evitar cololar en el controlador
View::template("rediseño"), simplemente se especifica en config.ini cual es el template por default.