### PR TITLE
Reparación de "invalid CRT parametre" sobre windows

### DIFF
--- a/default/app/views/pages/kumbia/status.phtml
+++ b/default/app/views/pages/kumbia/status.phtml
@@ -1,6 +1,12 @@
 <div id='info'>
 <?php
-    echo strftime("%e de %B del %Y")."<br />";
+    // Controlando si se ejecuta en windows para que no de problemas la funcion
+    if (PHP_OS == 'WINNT') {
+        echo strftime("%#d de %B del %Y") . "<br />";
+    } else {
+        echo strftime("%e de %B del %Y")."<br />";
+    }
+    
 
     /**
      * Verificando permisos del dir temp/


### PR DESCRIPTION
La función strftime() no entiende el parametro %e en windows así que necesita un condicional para si es windows usar el %#d