### PR TITLE
issue en console controller create

### DIFF
--- a/core/kumbia/console.php
+++ b/core/kumbia/console.php
@@ -37,6 +37,14 @@ require CORE_PATH . 'kumbia/config.php';
 require CORE_PATH . 'kumbia/load.php';
 
 /**
+ * modificado por nelsonrojas
+ * el problema: al usar console controller create produce un error en linea 85.
+ *              no reconoce FileUtil
+ * solucion: incluir la libreria con la linea siguiente
+ */
+require CORE_PATH . 'libs/file_util/file_util.php';
+
+/**
  * Manejador de consolas de KumbiaPHP
  *
  * Consola para la creación de modelos.


### PR DESCRIPTION
He estado probando la funcionalidad de creacion de controladores por consola y he encontrado el error en la linea 85 del archivo core/console/controller_console.php, pues no reconoce la  librería FileUtil y no logra crear la carpeta de las vistas. 
He hecho la prueba sin FileUtil (solo con mkdir) y resulta bien, pero supuse que FileUtil tiene un motivo, así que propongo este cambio pues solo con la modificacion ha pasado el create controller con toda su funcionalidad.
