### PR TITLE
Correcto funcionamiento de response

### DIFF
--- a/core/kumbia/kumbia_view.php
+++ b/core/kumbia/kumbia_view.php
@@ -111,7 +111,14 @@ class KumbiaView
      */
     public static function response($response, $template = FALSE)
     {
-        self::$_response = $response;
+        //self::$_response = $response;
+        
+        //se mantiene pero ya esta deprecated
+        if ($response == 'view') { 
+            self::$_template = NULL;
+        } else {
+            self::$_response = $response;
+        }
 
         // verifica si se indico template
         if ($template !== FALSE) {


### PR DESCRIPTION
No me pone bien las vistas, sólo me funcionó agregando ese código (aunque diga que es deprecated) supongo que se olvidó agregar esa condición en la que si la respuesta que se quiere es la vista se debe omitir el template, en otro caso poner la respuesta correspondiente