### PR TITLE
Correcto uso de $.on()

### DIFF
--- a/default/public/javascript/jquery/jquery.kumbiaphp.js
+++ b/default/public/javascript/jquery/jquery.kumbiaphp.js
@@ -130,34 +130,34 @@
 		 */
 		bind : function() {
             // Enlace y boton con confirmacion
-            $(document).on('click', "a.js-confirm, input.js-confirm",this.cConfirm);
+            $("body").on('click', "a.js-confirm, input.js-confirm",this.cConfirm);
 
             // Enlace ajax
-            $(document).on('click', "a.js-remote",this.cRemote);
+            $("body").on('click', "a.js-remote",this.cRemote);
 
             // Enlace ajax con confirmacion
-            $(document).on('click', "a.js-remote-confirm",this.cRemoteConfirm);
+            $("body").on('click', "a.js-remote-confirm",this.cRemoteConfirm);
 
             // Efecto show
-            $(document).on('click', "a.js-show",this.cFx('show'));
+            $("body").on('click', "a.js-show",this.cFx('show'));
 
             // Efecto hide
-            $(document).on('click', "a.js-hide",this.cFx('hide'));
+            $("body").on('click', "a.js-hide",this.cFx('hide'));
 
             // Efecto toggle
-            $(document).on('click', "a.js-toggle",this.cFx('toggle'));
+            $("body").on('click', "a.js-toggle",this.cFx('toggle'));
 
             // Efecto fadeIn
-            $(document).on('click', "a.js-fade-in",this.cFx('fadeIn'));
+            $("body").on('click', "a.js-fade-in",this.cFx('fadeIn'));
 
             // Efecto fadeOut
-            $(document).on('click', "a.js-fade-out",this.cFx('fadeOut'));
+            $("body").on('click', "a.js-fade-out",this.cFx('fadeOut'));
 
             // Formulario ajax
-            $(document).on('submit',"form.js-remote", this.cFRemote);
+            $("body").on('submit',"form.js-remote", this.cFRemote);
 
             // Lista desplegable que actualiza con ajax
-            $(document).on('change',"select.js-remote", this.cUpdaterSelect);
+            $("body").on('change',"select.js-remote", this.cUpdaterSelect);
 
             // Enlazar DatePicker
 			$.KumbiaPHP.bindDatePicker();

--- a/default/public/javascript/jquery/jquery.kumbiaphp.js
+++ b/default/public/javascript/jquery/jquery.kumbiaphp.js
@@ -130,35 +130,35 @@
 		 */
 		bind : function() {
             // Enlace y boton con confirmacion
-			$("a.js-confirm, input.js-confirm").on('click', this.cConfirm);
+            $(document).on('click', "a.js-confirm, input.js-confirm",this.cConfirm);
 
             // Enlace ajax
-			$("a.js-remote").on('click', this.cRemote);
+            $(document).on('click', "a.js-remote",this.cRemote);
 
             // Enlace ajax con confirmacion
-			$("a.js-remote-confirm").on('click', this.cRemoteConfirm);
+            $(document).on('click', "a.js-remote-confirm",this.cRemoteConfirm);
 
             // Efecto show
-			$("a.js-show").on('click', this.cFx('show'));
+            $(document).on('click', "a.js-show",this.cFx('show'));
 
             // Efecto hide
-			$("a.js-hide").on('click', this.cFx('hide'));
+            $(document).on('click', "a.js-hide",this.cFx('hide'));
 
             // Efecto toggle
-			$("a.js-toggle").on('click', this.cFx('toggle'));
+            $(document).on('click', "a.js-toggle",this.cFx('toggle'));
 
             // Efecto fadeIn
-			$("a.js-fade-in").on('click', this.cFx('fadeIn'));
+            $(document).on('click', "a.js-fade-in",this.cFx('fadeIn'));
 
             // Efecto fadeOut
-			$("a.js-fade-out").on('click', this.cFx('fadeOut'));
+            $(document).on('click', "a.js-fade-out",this.cFx('fadeOut'));
 
             // Formulario ajax
-			$("form.js-remote").on('submit', this.cFRemote);
+            $(document).on('submit',"form.js-remote", this.cFRemote);
 
             // Lista desplegable que actualiza con ajax
-            $("select.js-remote").on('change', this.cUpdaterSelect);
-            
+            $(document).on('change',"select.js-remote", this.cUpdaterSelect);
+
             // Enlazar DatePicker
 			$.KumbiaPHP.bindDatePicker();
 			


### PR DESCRIPTION
Aquí hago la corrección solamente en donde se hace uso de $.on(), recordemos que a partir de la versión 1.9 de jquery la función live() es deprecated. http://api.jquery.com/on/ 

Respecto a cUpdaterSelect, no funciona (al menos a mí) pues siempre toma como índice 'id' en el objeto que se envia por get. Por eso propuse en el otro commit el código usado en beta 1