### PR TITLE
Omisión de $this->_algos y Llamada a modelo

### DIFF
--- a/core/libs/auth2/adapters/model_auth.php
+++ b/core/libs/auth2/adapters/model_auth.php
@@ -108,12 +108,11 @@ class ModelAuth extends Auth2
         }
 
         // TODO: revisar seguridad
-        $password = hash($this->_algos, $password);
+        $password = ($this->_algos)? hash($this->_algos, $password) : $password;
         //$username = addslashes($username);
         $username = filter_var($username, FILTER_SANITIZE_MAGIC_QUOTES);
 
-        $Model = new $this->_model;
-        if ($user = $Model->find_first("$this->_login = '$username' AND $this->_pass = '$password'")) {
+        if ($user = Load::model($this->_model)->find_first("$this->_login = '$username' AND $this->_pass = '$password'")) {
             // Carga los atributos indicados en sesion
             foreach ($this->_fields as $field) {
                 Session::set($field, $user->$field, $this->_sessionNamespace);


### PR DESCRIPTION
Que tal, al tratar de implementar un proyecto con la librería Auth2, me topé con 2 probelmas, el primero es que en mi caso, para codificar una contraseña, uso algoritmos propios de la empresa para la que trabajo y no necesito especificar si es MD5, crc32 etc, por lo que considero mejor pasar la clave ya codificada, haciendo que modifiquemos la línea a:

$password = ($this->_algos)? hash($this->_algos, $password) : $password;

El otro asunto con el que me topé es que al querer obtener una instancia del modelo que usamos para hacer el logueo, me da error de "Fatal error: Cannot redeclare class" por lo que opté por usar la función Load::model y dicho error desapareció.
