### PR TITLE
Update jquery.kumbiaphp.js

### DIFF
--- a/default/public/javascript/jquery/jquery.kumbiaphp.js
+++ b/default/public/javascript/jquery/jquery.kumbiaphp.js
@@ -96,9 +96,12 @@
 			este = $(this);
 			var button = $('[type=submit]', este);
 			button.attr('disabled', 'disabled');
+			var btn_name = button.attr('name');
+			var btn_val = button.val();
 			var url = este.attr('action');
 			var div = este.attr('data-to');
-			$.post(url, este.serialize(), function(data, status){
+			var post = btn_name+'='+btn_val+'&'+este.serialize();
+			$.post(url, post, function(data){
 				var capa = $('#'+div);
 				capa.html(data);
 				capa.hide();


### PR DESCRIPTION
Con este cambio enviamos el name y value del boton que envía el formulario; Algo que no hace el serialize del jQuery.
https://api.jquery.com/serialize/
Y de este enlace extraigo este parrafo:
"Note: Only "successful controls" are serialized to the string. No submit button value is serialized since the form was not submitted using a button. For a form element's value to be included in the serialized string, the element must have a name attribute. Values from checkboxes and radio buttons (inputs of type "radio" or "checkbox") are included only if they are checked. Data from file select elements is not serialized."
Y de este parrafo esta frase:
"No submit button value is serialized since the form was not submitted using a button"
