### PR TITLE
Nombre de la clase a smallcase

### DIFF
--- a/core/libs/kumbia_active_record/kumbia_active_record.php
+++ b/core/libs/kumbia_active_record/kumbia_active_record.php
@@ -2478,6 +2478,7 @@ class KumbiaActiveRecord
             /**
              * Carga la clase
              * */
+			$model = Util::smallcase($Model);
             $file = APP_PATH . "models/$model.php";
             if (is_file($file)) {
                 include $file;


### PR DESCRIPTION
Cuando se realiza ralacion por medio de belongs_to por ejemplo,
intentaba cargar el archimo con el nombre de la clase, por lo que se
tiene que pasar smallcase para cargar el archivo correcto.

https://github.com/KumbiaPHP/KumbiaPHP/issues/259