### PR TITLE
Correccion de detalle por smallcase de model_form que no guarda al us…

### DIFF
--- a/core/extensions/helpers/model_form.php
+++ b/core/extensions/helpers/model_form.php
@@ -33,7 +33,7 @@ class ModelForm
     public static function create($model, $action = NULL)
     {
 
-        $model_name = Util::smallcase(get_class($model));
+        $model_name = get_class($model);
         if (!$action)
             $action = ltrim(Router::get('route'), '/');
 

--- a/default/app/libs/scaffold_controller.php
+++ b/default/app/libs/scaffold_controller.php
@@ -23,11 +23,11 @@ class ScaffoldController extends AdminController
      */
     public function crear()
     {
-        if (Input::hasPost(Util::smallcase($this->model))) {
+        if (Input::hasPost($this->model)) {
 
             $obj = new $this->model;
             //En caso que falle la operación de guardar
-            if (!$obj->save(Input::post(Util::smallcase($this->model)))) {
+            if (!$obj->save(Input::post($this->model))) {
                 Flash::error('Falló Operación');
                 //se hacen persistente los datos en el formulario
                 $this->{$this->model} = $obj;
@@ -47,12 +47,12 @@ class ScaffoldController extends AdminController
         View::select('crear');
 
         //se verifica si se ha enviado via POST los datos
-        if (Input::hasPost(Util::smallcase($this->model))) {
+        if (Input::hasPost($this->model)) {
             $obj = new $this->model;
-            if (!$obj->update(Input::post(Util::smallcase($this->model)))) {
+            if (!$obj->update(Input::post($this->model))) {
                 Flash::error('Falló Operación');
                 //se hacen persistente los datos en el formulario
-                $this->{$this->model} = Input::post(Util::smallcase($this->model));
+                $this->{$this->model} = Input::post($this->model);
             } else {
                 return Redirect::to();
             }

--- a/default/app/libs/scaffold_controller.php
+++ b/default/app/libs/scaffold_controller.php
@@ -23,11 +23,11 @@ class ScaffoldController extends AdminController
      */
     public function crear()
     {
-        if (Input::hasPost($this->model)) {
+        if (Input::hasPost(Util::smallcase($this->model))) {
 
             $obj = new $this->model;
             //En caso que falle la operación de guardar
-            if (!$obj->save(Input::post($this->model))) {
+            if (!$obj->save(Input::post(Util::smallcase($this->model)))) {
                 Flash::error('Falló Operación');
                 //se hacen persistente los datos en el formulario
                 $this->{$this->model} = $obj;
@@ -47,12 +47,12 @@ class ScaffoldController extends AdminController
         View::select('crear');
 
         //se verifica si se ha enviado via POST los datos
-        if (Input::hasPost($this->model)) {
+        if (Input::hasPost(Util::smallcase($this->model))) {
             $obj = new $this->model;
-            if (!$obj->update(Input::post($this->model))) {
+            if (!$obj->update(Input::post(Util::smallcase($this->model)))) {
                 Flash::error('Falló Operación');
                 //se hacen persistente los datos en el formulario
-                $this->{$this->model} = Input::post($this->model);
+                $this->{$this->model} = Input::post(Util::smallcase($this->model));
             } else {
                 return Redirect::to();
             }

--- a/default/app/views/_shared/scaffolds/kumbia/index.phtml
+++ b/default/app/views/_shared/scaffolds/kumbia/index.phtml
@@ -4,7 +4,7 @@
 <div class="actions">
     <?= Html::linkAction("crear/", 'Crear registro', 'class="btn btn-primary"')?>
 </div>
-<?php if (isset($data->items)) : ?>
+<?php if (isset($data->items) && (count($data->items) > 0)) : ?>
 <table class="t">
     <thead><tr>
     <?php foreach (current($data->items)->fields as $field) : ?>


### PR DESCRIPTION
Luego de la modificación en ScaffoldController para permitir el uso de modelos en CamelCase, el ModelForm expone el modelo en smallcase, por lo que la acción de crear y editar no encuentran la clave dentro de Input::post