### PR TITLE
Problemas con linkConfirm y linkActionConfirm de ajax.php ya que no aparecia mensaje escrito

### DIFF
--- a/core/extensions/helpers/ajax.php
+++ b/core/extensions/helpers/ajax.php
@@ -70,7 +70,7 @@ class Ajax
     public static function linkConfirm($action, $text, $update, $confirm, $class = '', $attrs = '')
     {
         $attrs = Tag::getAttrs($attrs);
-        return '<a href="' . PUBLIC_PATH . "$action\" class=\"js-remote-confirm $class\" data-to=\"{$update}\" title=\"$confirm\" $attrs>$text</a>";
+        return '<a href="' . PUBLIC_PATH . "$action\" data-msg=\"$confirm\" class=\"js-remote-confirm $class\" data-to=\"{$update}\" title=\"$confirm\" $attrs>$text</a>";
     }
 
     /**
@@ -88,7 +88,7 @@ class Ajax
     public static function linkActionConfirm($action, $text, $update, $confirm, $class = '', $attrs = '')
     {
         $attrs = Tag::getAttrs($attrs);
-        return '<a href="' . PUBLIC_PATH . Router::get('controller_path') . "/$action\" class=\"js-remote-confirm $class\" data-to=\"{$update}\" title=\"$confirm\" $attrs>$text</a>";
+        return '<a href="' . PUBLIC_PATH . Router::get('controller_path') . "/$action\" data-msg=\"$confirm\" class=\"js-remote-confirm $class\" data-to=\"{$update}\" title=\"$confirm\" $attrs>$text</a>";
     }
 
     /**


### PR DESCRIPTION
// antes estaba asi:

 public static function linkConfirm($action, $text, $update, $confirm, $class = '', $attrs = '')
    {
        $attrs = Tag::getAttrs($attrs);
        return '<a href="' . PUBLIC_PATH . "$action\" class=\"js-remote-confirm $class\" data-to=\"{$update}\" title=\"$confirm\" $attrs>$text</a>";
    }
	
// lo modifique colocandole data-msg=\"$confirm\"

// y que do asi:

    public static function linkConfirm($action, $text, $update, $confirm, $class = '', $attrs = '')
    {
        $attrs = Tag::getAttrs($attrs);
        return '<a href="' . PUBLIC_PATH . "$action\" data-msg=\"$confirm\" class=\"js-remote-confirm $class\" data-to=\"{$update}\" title=\"$confirm\" $attrs>$text</a>";
    }

el cambio se debe hacer igual en linkActionConfirm