### PR TITLE
Just to avoid to generate a PHP warning

### DIFF
--- a/core/kumbia/kumbia_router.php
+++ b/core/kumbia/kumbia_router.php
@@ -107,8 +107,10 @@ class KumbiaRouter
     {
         // Extrae las variables para manipularlas facilmente
         extract($param, EXTR_OVERWRITE);
-        if (!include_once "$default_path{$dir}/$controller_path{$suffix}") {
-            throw new KumbiaException('', 'no_controller');
+        if (file_exists("$default_path{$dir}/$controller_path{$suffix}")) {
+            include_once "$default_path{$dir}/$controller_path{$suffix}";
+        } else {
+            throw new KumbiaException(null, 'no_controller');
         }
         //Asigna el controlador activo
         $app_controller = Util::camelcase($controller).'Controller';


### PR DESCRIPTION
When someone tries to open a file which doesn't exist, PHP raises a warning because on line 114 the include_once is called with ! in an if clause. Checking if the controller kumbia tries to open exist before opening it, it avoid this warning.