### PR TITLE
Renderiza una vista en formato JSON

### DIFF
--- a/core/kumbia/kumbia_view.php
+++ b/core/kumbia/kumbia_view.php
@@ -376,6 +376,19 @@ class KumbiaView
 
         return isset(self::$_controller[$var]) ? self::$_controller[$var] : null;
     }
+    
+    /**
+     * Devuelve la respuesta en formato JSON
+     * application/json 
+     *  
+     * @param type $data
+     */
+	public static function json($data)
+	{
+        View::select(null, null);
+        header('Content-type: application/json');
+        echo json_encode($data);
+    }
 }
 
 /**


### PR DESCRIPTION
Permite renderizar la vista en formato JSON, sin necesidad de que el controlador extienda de RestController.
Content-type: application/json
uso   View::json($data);