### PR TITLE
Se añade un cast string para compatibilidad php8.1

### DIFF
--- a/core/extensions/helpers/flash.php
+++ b/core/extensions/helpers/flash.php
@@ -56,7 +56,7 @@ class Flash
      */
     public static function error($text)
     {
-        self::show('error', $text);
+        return self::show('error', $text);
     }
 
     /**
@@ -66,7 +66,7 @@ class Flash
      */
     public static function warning($text)
     {
-        self::show('warning', $text);
+        return self::show('warning', $text);
     }
 
     /**
@@ -76,7 +76,7 @@ class Flash
      */
     public static function info($text)
     {
-        self::show('info', $text);
+        return self::show('info', $text);
     }
 
     /**
@@ -86,7 +86,7 @@ class Flash
      */
     public static function valid($text)
     {
-        self::show('valid', $text);
+        return self::show('valid', $text);
     }
 
 }

--- a/core/extensions/helpers/flash.php
+++ b/core/extensions/helpers/flash.php
@@ -56,7 +56,7 @@ class Flash
      */
     public static function error($text)
     {
-        return self::show('error', $text);
+        self::show('error', $text);
     }
 
     /**
@@ -66,7 +66,7 @@ class Flash
      */
     public static function warning($text)
     {
-        return self::show('warning', $text);
+        self::show('warning', $text);
     }
 
     /**
@@ -76,7 +76,7 @@ class Flash
      */
     public static function info($text)
     {
-        return self::show('info', $text);
+        self::show('info', $text);
     }
 
     /**
@@ -86,7 +86,7 @@ class Flash
      */
     public static function valid($text)
     {
-        return self::show('valid', $text);
+        self::show('valid', $text);
     }
 
 }

--- a/core/libs/kumbia_active_record/kumbia_active_record.php
+++ b/core/libs/kumbia_active_record/kumbia_active_record.php
@@ -1142,7 +1142,7 @@ class KumbiaActiveRecord
         if (is_array($result)) {
             foreach ($result as $k => $r) {
                 if (!is_numeric($k)) {
-                    $obj->$k = stripslashes($r);
+                    $obj->$k = stripslashes((string) $r);
                 }
             }
         }
@@ -1163,7 +1163,7 @@ class KumbiaActiveRecord
         if (is_array($result)) {
             foreach ($result as $k => $r) {
                 if (!is_numeric($k)) {
-                    $this->$k = stripslashes($r);
+                    $this->$k = stripslashes((string) $r);
                 }
             }
         }


### PR DESCRIPTION
Se añade un cast string para compatibilidad, pues en php8.1 la función stripslashes necesita como parámetro un string.