### PR TITLE
datetime input type deprecated

### DIFF
--- a/core/extensions/helpers/form.php
+++ b/core/extensions/helpers/form.php
@@ -605,7 +605,7 @@ class Form
      */
     public static function datetime($field, $attrs = '', $value = null)
     {
-        return self::input('datetime', $field, $attrs, $value);
+        return self::input('datetime-local', $field, $attrs, $value);
     }
 
     /**


### PR DESCRIPTION
The "datetime" input type is deprecated  , the new available type is "datetime-local" https://www.w3schools.com/tags/att_input_type_datetime-local.asp