### PR TITLE
Cast string para compatibilidad >php8.1

### DIFF
--- a/core/kumbia/controller.php
+++ b/core/kumbia/controller.php
@@ -53,7 +53,7 @@ abstract class Controller
      *
      * @var bool
      */
-    public bool $limit_params = true;
+    public $limit_params = true;
     /**
      * Nombre del scaffold a usar
      *

--- a/core/libs/kumbia_active_record/kumbia_active_record.php
+++ b/core/libs/kumbia_active_record/kumbia_active_record.php
@@ -1154,7 +1154,7 @@ class KumbiaActiveRecord
             foreach ($result as $k => $r) {
                 if (!is_numeric($k)) {
                     if (!is_object($r)) {
-                        $obj->$k = stripslashes($r);
+                        $obj->$k = stripslashes((string)$r);
                     } else {
                         $obj->$k = $r->load();
                     }
@@ -1181,7 +1181,7 @@ class KumbiaActiveRecord
             foreach ($result as $k => $r) {
                 if (!is_numeric($k)) {
                     if (!is_object($r)) {
-                        $this->$k = is_array($r) ? $r : stripslashes($r);
+                        $this->$k = is_array($r) ? $r : stripslashes((string)$r);
                     } else {
                         $this->$k = $r->load();
                     }


### PR DESCRIPTION
la función stripslashes(string $string): string necesita recibir un string. Se añade cast string para asegurarlo.