### PR TITLE
Use method to resolve application path for console

### DIFF
--- a/core/kumbia/console.php
+++ b/core/kumbia/console.php
@@ -155,7 +155,7 @@ class Console
         }
 
         // define el path de la aplicacion
-        define('APP_PATH', rtrim($dir, '/') . '/');
+        define('APP_PATH', self::resolveAppPath($dir));
 
         // lee la configuracion
         $config = Config::read('config');
@@ -212,4 +212,26 @@ class Console
         return $data;
     }
 
+    /**
+     * Resuelve la ruta de aplicación para consola.
+     *
+     * Resuelve el path de la aplicación bajo la estructura estándar de KumbiaPHP,
+     * donde el app vive en default/app/ relativo a la raíz del proyecto.
+     *
+     * @param string $dir Directorio raíz del proyecto recibido desde terminal
+     *
+     * @throws KumbiaException
+     * @return string
+     */
+    private static function resolveAppPath(string $dir): string
+    {
+        $path = rtrim($dir, '/') . '/default/app/';
+
+        if (is_dir("{$path}config")
+                && (is_file("{$path}config/config.php") || is_file("{$path}config/config.ini"))) {
+            return $path;
+        }
+
+        throw new KumbiaException('No se encontró la aplicación. Use --path con la ruta de app');
+    }
 }

--- a/core/kumbia/console.php
+++ b/core/kumbia/console.php
@@ -143,15 +143,23 @@ class Console
 
         // verifica el path de aplicacion
         if (isset($args[0]['path'])) {
-            $dir = realpath($args[0]['path']);
+            $path = $args[0]['path'];
+            $dir = realpath($path);
+            $trimmedPath = rtrim($path, '/\\');
+            if ($dir === false && $trimmedPath !== '') {
+                $dir = realpath($trimmedPath);
+            }
             if (!$dir) {
-                throw new KumbiaException("La ruta \"{$args[0]['path']}\" es invalida");
+                throw new KumbiaException("La ruta \"$path\" es invalida");
             }
             // elimina el parametro path del array
             unset($args[0]['path']);
         } else {
             // obtiene el directorio de trabajo actual
             $dir = getcwd();
+            if ($dir === false) {
+                throw new KumbiaException('No se pudo obtener el directorio de trabajo actual');
+            }
         }
 
         // define el path de la aplicacion
@@ -213,25 +221,36 @@ class Console
     }
 
     /**
-     * Resuelve la ruta de aplicación para consola.
+     * Resolves the console application path from an app directory or project root.
      *
-     * Resuelve el path de la aplicación bajo la estructura estándar de KumbiaPHP,
-     * donde el app vive en default/app/ relativo a la raíz del proyecto.
-     *
-     * @param string $dir Directorio raíz del proyecto recibido desde terminal
+     * @param string $dir Application directory or KumbiaPHP project root
      *
      * @throws KumbiaException
-     * @return string
+     * @return string Canonical application path with one trailing separator
      */
     private static function resolveAppPath(string $dir): string
     {
-        $path = rtrim($dir, '/') . '/default/app/';
+        $candidates = [
+            $dir,
+            $dir . DIRECTORY_SEPARATOR . 'default' . DIRECTORY_SEPARATOR . 'app',
+        ];
 
-        if (is_dir("{$path}config")
-                && (is_file("{$path}config/config.php") || is_file("{$path}config/config.ini"))) {
-            return $path;
+        foreach ($candidates as $candidate) {
+            $path = rtrim($candidate, '/\\');
+            $path = $path === '' ? DIRECTORY_SEPARATOR : $path;
+            $config = $path . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config';
+
+            if (is_file("$config.php") || is_file("$config.ini")) {
+                $resolved = realpath($candidate);
+                if ($resolved !== false) {
+                    return rtrim($resolved, '/\\') . DIRECTORY_SEPARATOR;
+                }
+            }
         }
 
-        throw new KumbiaException('No se encontró la aplicación. Use --path con la ruta de app');
+        throw new KumbiaException(
+            'No se encontró la aplicación. --path puede apuntar al directorio de la aplicación '
+            . 'o a la raíz del proyecto KumbiaPHP'
+        );
     }
 }

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * KumbiaPHP web & app Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.
+ *
+ * @category   Test
+ * @package    Core
+ *
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
+ */
+
+class ConsoleTest extends PHPUnit\Framework\TestCase
+{
+    private $consoleEntrypoint;
+    private $temporaryDirectory;
+
+    protected function setUp(): void
+    {
+        $this->consoleEntrypoint = dirname(__DIR__, 3) . '/console/kumbia.php';
+        $this->temporaryDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR
+            . 'kumbia console ' . bin2hex(random_bytes(8));
+
+        if (!mkdir($this->temporaryDirectory, 0777, true)) {
+            $this->fail('Unable to create the temporary test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->temporaryDirectory);
+    }
+
+    public function testDirectAppPathRemainsAccepted(): void
+    {
+        $app = $this->temporaryDirectory . '/custom-app';
+        $this->createApp($app);
+
+        $result = $this->runConsole($app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testCurrentDirectoryRemainsAcceptedAsDirectApp(): void
+    {
+        $app = $this->temporaryDirectory . '/current-app';
+        $this->createApp($app);
+
+        $result = $this->runConsole(null, $app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testProjectRootResolvesDefaultApp(): void
+    {
+        $root = $this->temporaryDirectory . '/project';
+        $app = $root . '/default/app';
+        $this->createApp($app);
+
+        $result = $this->runConsole($root);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testDirectAppWinsWhenProjectRootFormAlsoExists(): void
+    {
+        $app = $this->temporaryDirectory . '/both';
+        $this->createApp($app);
+        $this->createApp($app . '/default/app');
+
+        $result = $this->runConsole($app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    /**
+     * @dataProvider configFileProvider
+     */
+    public function testConfigFileIdentifiesAnApp(string $configFile): void
+    {
+        $app = $this->temporaryDirectory . '/config-app';
+        $this->createApp($app, $configFile);
+
+        $result = $this->runConsole($app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function configFileProvider(): array
+    {
+        return [
+            ['config.php'],
+            ['config.ini'],
+        ];
+    }
+
+    /**
+     * @dataProvider trailingSeparatorProvider
+     */
+    public function testAcceptedPathHasOnePlatformSeparator(string $separator): void
+    {
+        $app = $this->temporaryDirectory . '/trailing-app';
+        $this->createApp($app);
+
+        $result = $this->runConsole($app . $separator);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function trailingSeparatorProvider(): array
+    {
+        return [
+            ['/'],
+            ['\\'],
+        ];
+    }
+
+    public function testMinimalAppWithoutMvcDirectoriesIsAccepted(): void
+    {
+        $app = $this->temporaryDirectory . '/minimal-app';
+        $this->createApp($app);
+
+        $this->assertDirectoryDoesNotExist($app . '/controllers');
+        $this->assertDirectoryDoesNotExist($app . '/models');
+        $this->assertDirectoryDoesNotExist($app . '/views');
+
+        $result = $this->runConsole($app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testSymlinkedAppResolvesCanonically(): void
+    {
+        $app = $this->temporaryDirectory . '/real-app';
+        $link = $this->temporaryDirectory . '/linked-app';
+        $this->createApp($app);
+
+        if (!function_exists('symlink') || !@symlink($app, $link)) {
+            $this->markTestSkipped('Symbolic links are not available');
+        }
+
+        $result = $this->runConsole($link);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testExistingInvalidDirectoryReportsAcceptedPathForms(): void
+    {
+        $invalid = $this->temporaryDirectory . '/invalid';
+        mkdir($invalid);
+
+        $result = $this->runConsole($invalid);
+
+        $this->assertNotSame(0, $result['status']);
+        $this->assertStringContainsString(
+            '--path puede apuntar al directorio de la aplicación o a la raíz del proyecto KumbiaPHP',
+            $result['stderr']
+        );
+    }
+
+    public function testNonexistentExplicitPathKeepsInvalidPathError(): void
+    {
+        $invalid = $this->temporaryDirectory . '/does-not-exist';
+
+        $result = $this->runConsole($invalid);
+
+        $this->assertNotSame(0, $result['status']);
+        $this->assertStringContainsString("La ruta \"$invalid\" es invalida", $result['stderr']);
+    }
+
+    private function createApp(string $app, string $configFile = 'config.php'): void
+    {
+        mkdir($app . '/config', 0777, true);
+        mkdir($app . '/extensions/console', 0777, true);
+
+        $config = $configFile === 'config.php'
+            ? "<?php\nreturn ['application' => ['production' => false]];\n"
+            : "[application]\nproduction = 0\n";
+        file_put_contents($app . "/config/$configFile", $config);
+        file_put_contents(
+            $app . '/extensions/console/path_probe_console.php',
+            "<?php\nclass PathProbeConsole\n{\n    public function main()\n    {\n        echo APP_PATH;\n    }\n}\n"
+        );
+    }
+
+    private function runConsole(?string $path, ?string $cwd = null): array
+    {
+        $command = [PHP_BINARY, $this->consoleEntrypoint, 'path_probe', 'main'];
+        if ($path !== null) {
+            $command[] = "--path=$path";
+        }
+
+        $process = proc_open(
+            $command,
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            $cwd ?? $this->temporaryDirectory
+        );
+        if (!is_resource($process)) {
+            $this->fail('Unable to start the console subprocess');
+        }
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return [
+            'status' => proc_close($process),
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+        ];
+    }
+
+    private function assertSuccessfulPath(array $result, string $app): void
+    {
+        $this->assertSame('', $result['stderr']);
+        $this->assertSame(0, $result['status']);
+        $this->assertSame(realpath($app) . DIRECTORY_SEPARATOR, $result['stdout']);
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            unlink($path);
+
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+
+        foreach (scandir($path) as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeDirectory($path . DIRECTORY_SEPARATOR . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
Refactors application path definition in the console to utilize a dedicated method, improving maintainability and ensuring the path is correctly resolved under KumbiaPHP's structure.

Enhances error handling by throwing an exception when the application directory is not found, guiding users to specify the correct path with a console argument.