### PR TITLE
fix: Store registry values as arrays to support multiple entries

### DIFF
--- a/core/libs/registry/registry.php
+++ b/core/libs/registry/registry.php
@@ -42,7 +42,7 @@ class Registry
      */
     public static function set($index, $value)
     {
-        self::$registry[$index] = $value;
+        self::$registry[$index] = [$value];
     }
 
     /**
@@ -79,7 +79,7 @@ class Registry
     {
         return self::$registry[$index] ?? null;
     }
-    
+
     /**
      * Crea un index si no existe
      *


### PR DESCRIPTION
Wraps assigned registry values in arrays to prepare for handling multiple values under a single index. Facilitates future expansion and avoids potential issues with inconsistent value types.

Related to #405