### PR TITLE
fix(auth): preserve Authorization under FastCGI

### DIFF
--- a/default/public/.htaccess
+++ b/default/public/.htaccess
@@ -4,6 +4,10 @@ DirectoryIndex index.php
     # Activar modo de reescritura
     RewriteEngine On
 
+    # Conserva la cabecera Authorization en entornos CGI/FastCGI
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
     # Directorio de instalacion, puede ser necesario si 
     # la aplicacion se ubica en public_html
     #RewriteBase /


### PR DESCRIPTION
Closes #284

## Summary

- Preserve the incoming `Authorization` header when KumbiaPHP runs behind Apache CGI/FastCGI.
- Let PHP-FPM populate its standard `PHP_AUTH_USER` and `PHP_AUTH_PW` server variables without adding framework-side credential parsing.
- Keep the rule before the existing front-controller rewrite so direct and rewritten requests behave consistently.

## Why this fixes the bug

Apache does not pass `Authorization` to CGI/FastCGI scripts by default. The current public `.htaccess` routes requests to `index.php`, but it does not copy that header into the FastCGI environment. Consequently, PHP-FPM cannot parse Basic credentials and the application never receives `PHP_AUTH_USER` or `PHP_AUTH_PW`.

The added rule only runs when `Authorization` is non-empty and exposes it as `HTTP_AUTHORIZATION`. PHP-FPM then performs its normal authentication-header parsing. The change does not decode, validate, log, or otherwise handle credentials in KumbiaPHP itself.

## Reproduction and verification

The behavior was exercised with an isolated local integration harness using:

- Apache 2.4.58 with `mod_proxy_fcgi` and `mod_rewrite`
- PHP-FPM 8.4.23
- curl 8.5.0

The same matrix was run against the original `.htaccess` and the modified repository file:

| Route | Authorization | Before | After |
|---|---|---|---|
| `/index.php` | None | Auth variables absent | Auth variables absent |
| `/probe` (front-controller rewrite) | None | Auth variables absent | Auth variables absent |
| `/index.php` | Basic `issue284:secret` | `HTTP_AUTHORIZATION` and `PHP_AUTH_*` absent | Header present; user/password exactly recovered |
| `/probe` (front-controller rewrite) | Basic `issue284:secret` | `HTTP_AUTHORIZATION` and `PHP_AUTH_*` absent | Header present; user/password exactly recovered |

Results:

- Apache/PHP-FPM configuration checks: **2/2 passed**
- HTTP request matrix: **8/8 passed**
- Before/after assertions: **8/8 passed**
- Default application PHPUnit suite: **1 test, 2 assertions, passed**
- `git diff --check`: passed

The post-fix harness used a byte-for-byte copy of the modified repository file, verified with SHA-256 `9fb04d81bb0c31c11e0a5e28fa43951979987268986305d14d5baf799a59ae79`.

## Scope

Only `default/public/.htaccess` changes. Existing routing behavior remains unchanged for requests without an `Authorization` header.
