### PR TITLE
chore(gitignore): ignore modern development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,16 +11,35 @@ default/public/temp
 # Sonarlint
 .sonarlint
 
+# PHPUnit
+/.phpunit.result.cache
+/.phpunit.cache/
+
+#### Local development tools:
+
+# AI agents
+/.atl/
+/.claude/
+/.codegraph/
+/.codex/
+/.cursor/
+
 #### Editors:
 
 # Netbeans
 /nbproject
 
 # Visual Studio Code
-.vscode
+/.vscode/
 
 # Intellij
-.idea
+/.idea/
+
+# Nova
+/.nova/
+
+# Zed
+/.zed/
 
 #sonar
 .sonar


### PR DESCRIPTION
Resolves #418

## Summary
- ignore PHPUnit result and cache artifacts at the repository root
- ignore local AI-agent and modern editor directories
- normalize existing IntelliJ and VS Code patterns as root-anchored directories

## Verification
- `git diff --check`
- `git check-ignore -v` matched all requested root-level paths
- confirmed `.gitignore` is the only changed file