### PR TITLE
fix(console): handle missing production setting

### DIFF
--- a/core/kumbia/console.php
+++ b/core/kumbia/console.php
@@ -169,7 +169,7 @@ class Console
         $config = Config::read('config');
 
         // constante que indica si la aplicacion se encuentra en produccion
-        define('PRODUCTION', $config['application']['production']);
+        define('PRODUCTION', $config['application']['production'] ?? false);
 
         // crea la consola
         $console = self::load($console_name);

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -98,6 +98,22 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         ];
     }
 
+    public function testConfiguredProductionValueIsPreserved(): void
+    {
+        $app = $this->temporaryDirectory . '/configured-production-app';
+        $this->createApp($app);
+        file_put_contents(
+            $app . '/config/config.php',
+            "<?php\nreturn ['application' => ['production' => 'configured']];\n"
+        );
+
+        $result = $this->runConsole($app, null, 'production');
+
+        $this->assertSame('', $result['stderr']);
+        $this->assertSame(0, $result['status']);
+        $this->assertSame('configured', $result['stdout']);
+    }
+
     /**
      * @dataProvider trailingSeparatorProvider
      */
@@ -178,18 +194,18 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         mkdir($app . '/extensions/console', 0777, true);
 
         $config = $configFile === 'config.php'
-            ? "<?php\nreturn ['application' => ['production' => false]];\n"
-            : "[application]\nproduction = 0\n";
+            ? "<?php\nreturn ['application' => []];\n"
+            : "[application]\n";
         file_put_contents($app . "/config/$configFile", $config);
         file_put_contents(
             $app . '/extensions/console/path_probe_console.php',
-            "<?php\nclass PathProbeConsole\n{\n    public function main()\n    {\n        echo APP_PATH;\n    }\n}\n"
+            "<?php\nclass PathProbeConsole\n{\n    public function main()\n    {\n        echo APP_PATH;\n    }\n\n    public function production()\n    {\n        echo PRODUCTION;\n    }\n}\n"
         );
     }
 
-    private function runConsole(?string $path, ?string $cwd = null): array
+    private function runConsole(?string $path, ?string $cwd = null, string $command = 'main'): array
     {
-        $command = [PHP_BINARY, $this->consoleEntrypoint, 'path_probe', 'main'];
+        $command = [PHP_BINARY, $this->consoleEntrypoint, 'path_probe', $command];
         if ($path !== null) {
             $command[] = "--path=$path";
         }


### PR DESCRIPTION
## Summary

- Default `PRODUCTION` to `false` when `application.production` is absent.
- Preserve explicitly configured production values without casting.
- Cover missing-key behavior for PHP and legacy INI application configs.

## Context

Follow-up to #407. The CLI runs in a separate PHP process and does not load `public/index.php`, while the default application config does not define `application.production`. This previously emitted an undefined array key warning before successfully executing console commands.

## Verification

- `ConsoleTest`: 13 tests, 40 assertions.
- Core suite: 134 tests, 242 assertions.
- PHP syntax and diff checks passed.
- Disposable `model create vehiculo` completed with exit code 0 and empty stderr.