### PR TITLE
Merge dev into master: console reliability and expanded test coverage

### DIFF
--- a/core/kumbia/console.php
+++ b/core/kumbia/console.php
@@ -155,7 +155,7 @@ class Console
         }
 
         // define el path de la aplicacion
-        define('APP_PATH', rtrim($dir, '/') . '/');
+        define('APP_PATH', self::resolveAppPath($dir));
 
         // lee la configuracion
         $config = Config::read('config');
@@ -212,4 +212,26 @@ class Console
         return $data;
     }
 
+    /**
+     * Resuelve la ruta de aplicación para consola.
+     *
+     * Resuelve el path de la aplicación bajo la estructura estándar de KumbiaPHP,
+     * donde el app vive en default/app/ relativo a la raíz del proyecto.
+     *
+     * @param string $dir Directorio raíz del proyecto recibido desde terminal
+     *
+     * @throws KumbiaException
+     * @return string
+     */
+    private static function resolveAppPath(string $dir): string
+    {
+        $path = rtrim($dir, '/') . '/default/app/';
+
+        if (is_dir("{$path}config")
+                && (is_file("{$path}config/config.php") || is_file("{$path}config/config.ini"))) {
+            return $path;
+        }
+
+        throw new KumbiaException('No se encontró la aplicación. Use --path con la ruta de app');
+    }
 }

--- a/core/kumbia/console.php
+++ b/core/kumbia/console.php
@@ -143,15 +143,23 @@ class Console
 
         // verifica el path de aplicacion
         if (isset($args[0]['path'])) {
-            $dir = realpath($args[0]['path']);
+            $path = $args[0]['path'];
+            $dir = realpath($path);
+            $trimmedPath = rtrim($path, '/\\');
+            if ($dir === false && $trimmedPath !== '') {
+                $dir = realpath($trimmedPath);
+            }
             if (!$dir) {
-                throw new KumbiaException("La ruta \"{$args[0]['path']}\" es invalida");
+                throw new KumbiaException("La ruta \"$path\" es invalida");
             }
             // elimina el parametro path del array
             unset($args[0]['path']);
         } else {
             // obtiene el directorio de trabajo actual
             $dir = getcwd();
+            if ($dir === false) {
+                throw new KumbiaException('No se pudo obtener el directorio de trabajo actual');
+            }
         }
 
         // define el path de la aplicacion
@@ -213,25 +221,36 @@ class Console
     }
 
     /**
-     * Resuelve la ruta de aplicación para consola.
+     * Resolves the console application path from an app directory or project root.
      *
-     * Resuelve el path de la aplicación bajo la estructura estándar de KumbiaPHP,
-     * donde el app vive en default/app/ relativo a la raíz del proyecto.
-     *
-     * @param string $dir Directorio raíz del proyecto recibido desde terminal
+     * @param string $dir Application directory or KumbiaPHP project root
      *
      * @throws KumbiaException
-     * @return string
+     * @return string Canonical application path with one trailing separator
      */
     private static function resolveAppPath(string $dir): string
     {
-        $path = rtrim($dir, '/') . '/default/app/';
+        $candidates = [
+            $dir,
+            $dir . DIRECTORY_SEPARATOR . 'default' . DIRECTORY_SEPARATOR . 'app',
+        ];
 
-        if (is_dir("{$path}config")
-                && (is_file("{$path}config/config.php") || is_file("{$path}config/config.ini"))) {
-            return $path;
+        foreach ($candidates as $candidate) {
+            $path = rtrim($candidate, '/\\');
+            $path = $path === '' ? DIRECTORY_SEPARATOR : $path;
+            $config = $path . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config';
+
+            if (is_file("$config.php") || is_file("$config.ini")) {
+                $resolved = realpath($candidate);
+                if ($resolved !== false) {
+                    return rtrim($resolved, '/\\') . DIRECTORY_SEPARATOR;
+                }
+            }
         }
 
-        throw new KumbiaException('No se encontró la aplicación. Use --path con la ruta de app');
+        throw new KumbiaException(
+            'No se encontró la aplicación. --path puede apuntar al directorio de la aplicación '
+            . 'o a la raíz del proyecto KumbiaPHP'
+        );
     }
 }

--- a/core/kumbia/console.php
+++ b/core/kumbia/console.php
@@ -169,7 +169,7 @@ class Console
         $config = Config::read('config');
 
         // constante que indica si la aplicacion se encuentra en produccion
-        define('PRODUCTION', $config['application']['production']);
+        define('PRODUCTION', $config['application']['production'] ?? false);
 
         // crea la consola
         $console = self::load($console_name);

--- a/core/tests/classes/extensions/helpers/CssTest.php
+++ b/core/tests/classes/extensions/helpers/CssTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * KumbiaPHP web & app Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.
+ *
+ * @category   Test
+ * @package    Css
+ *
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
+ */
+
+/**
+ * @category    Test
+ * @package     Css
+ */
+class CssTest extends PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        Closure::bind(static function () {
+            Css::$_css = [];
+            Css::$_dependencies = [];
+        }, null, Css::class)();
+    }
+
+    public function testIncReturnsEmptyStringWhenNothingAdded()
+    {
+        $this->assertSame('', Css::inc());
+    }
+
+    public function testAddSingleFile()
+    {
+        Css::add('style');
+
+        $expected = '<link href="' . PUBLIC_PATH . 'css/style.css" rel="stylesheet" type="text/css" />' . PHP_EOL;
+        $this->assertSame($expected, Css::inc());
+    }
+
+    public function testAddMultipleFilesPreservesInsertionOrder()
+    {
+        Css::add('reset');
+        Css::add('base');
+        Css::add('main');
+
+        $expected =
+            '<link href="' . PUBLIC_PATH . 'css/reset.css" rel="stylesheet" type="text/css" />' . PHP_EOL .
+            '<link href="' . PUBLIC_PATH . 'css/base.css" rel="stylesheet" type="text/css" />' . PHP_EOL .
+            '<link href="' . PUBLIC_PATH . 'css/main.css" rel="stylesheet" type="text/css" />' . PHP_EOL;
+
+        $this->assertSame($expected, Css::inc());
+    }
+
+    public function testDependenciesAreOutputBeforeMainFile()
+    {
+        Css::add('main', ['reset', 'base']);
+
+        $output   = Css::inc();
+        $resetPos = strpos($output, 'reset.css');
+        $basePos  = strpos($output, 'base.css');
+        $mainPos  = strpos($output, 'main.css');
+
+        $this->assertLessThan($mainPos, $resetPos, 'reset.css should appear before main.css');
+        $this->assertLessThan($mainPos, $basePos,  'base.css should appear before main.css');
+    }
+
+    public function testAllDependenciesAndMainFileAreIncluded()
+    {
+        Css::add('app', ['normalize', 'grid']);
+
+        $output = Css::inc();
+
+        $this->assertStringContainsString(PUBLIC_PATH . 'css/normalize.css', $output);
+        $this->assertStringContainsString(PUBLIC_PATH . 'css/grid.css', $output);
+        $this->assertStringContainsString(PUBLIC_PATH . 'css/app.css', $output);
+    }
+
+    public function testAddingSameFileMultipleTimesDeduplicates()
+    {
+        Css::add('style');
+        Css::add('style');
+
+        $this->assertSame(1, substr_count(Css::inc(), 'style.css'));
+    }
+
+    public function testAddingSameDependencyFromMultipleCallsDeduplicates()
+    {
+        Css::add('comp-a', ['shared']);
+        Css::add('comp-b', ['shared']);
+
+        $this->assertSame(1, substr_count(Css::inc(), 'shared.css'));
+    }
+
+    public function testFileUsedAsBothDependencyAndMainAppearsOnce()
+    {
+        Css::add('base');
+        Css::add('main', ['base']);
+
+        $this->assertSame(1, substr_count(Css::inc(), 'base.css'));
+    }
+
+    public function testIncIsIdempotent()
+    {
+        Css::add('style');
+
+        $this->assertSame(Css::inc(), Css::inc());
+    }
+
+    public function testAddFileWithSubdirectoryPath()
+    {
+        Css::add('vendor/bootstrap');
+
+        $expected = '<link href="' . PUBLIC_PATH . 'css/vendor/bootstrap.css" rel="stylesheet" type="text/css" />' . PHP_EOL;
+        $this->assertSame($expected, Css::inc());
+    }
+}

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * KumbiaPHP web & app Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.
+ *
+ * @category   Test
+ * @package    Core
+ *
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
+ */
+
+class ConsoleTest extends PHPUnit\Framework\TestCase
+{
+    private $consoleEntrypoint;
+    private $temporaryDirectory;
+
+    protected function setUp(): void
+    {
+        $this->consoleEntrypoint = dirname(__DIR__, 3) . '/console/kumbia.php';
+        $this->temporaryDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR
+            . 'kumbia console ' . bin2hex(random_bytes(8));
+
+        if (!mkdir($this->temporaryDirectory, 0777, true)) {
+            $this->fail('Unable to create the temporary test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->temporaryDirectory);
+    }
+
+    public function testDirectAppPathRemainsAccepted(): void
+    {
+        $app = $this->temporaryDirectory . '/custom-app';
+        $this->createApp($app);
+
+        $result = $this->runConsole($app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testCurrentDirectoryRemainsAcceptedAsDirectApp(): void
+    {
+        $app = $this->temporaryDirectory . '/current-app';
+        $this->createApp($app);
+
+        $result = $this->runConsole(null, $app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testProjectRootResolvesDefaultApp(): void
+    {
+        $root = $this->temporaryDirectory . '/project';
+        $app = $root . '/default/app';
+        $this->createApp($app);
+
+        $result = $this->runConsole($root);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testDirectAppWinsWhenProjectRootFormAlsoExists(): void
+    {
+        $app = $this->temporaryDirectory . '/both';
+        $this->createApp($app);
+        $this->createApp($app . '/default/app');
+
+        $result = $this->runConsole($app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    /**
+     * @dataProvider configFileProvider
+     */
+    public function testConfigFileIdentifiesAnApp(string $configFile): void
+    {
+        $app = $this->temporaryDirectory . '/config-app';
+        $this->createApp($app, $configFile);
+
+        $result = $this->runConsole($app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function configFileProvider(): array
+    {
+        return [
+            ['config.php'],
+            ['config.ini'],
+        ];
+    }
+
+    /**
+     * @dataProvider trailingSeparatorProvider
+     */
+    public function testAcceptedPathHasOnePlatformSeparator(string $separator): void
+    {
+        $app = $this->temporaryDirectory . '/trailing-app';
+        $this->createApp($app);
+
+        $result = $this->runConsole($app . $separator);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function trailingSeparatorProvider(): array
+    {
+        return [
+            ['/'],
+            ['\\'],
+        ];
+    }
+
+    public function testMinimalAppWithoutMvcDirectoriesIsAccepted(): void
+    {
+        $app = $this->temporaryDirectory . '/minimal-app';
+        $this->createApp($app);
+
+        $this->assertDirectoryDoesNotExist($app . '/controllers');
+        $this->assertDirectoryDoesNotExist($app . '/models');
+        $this->assertDirectoryDoesNotExist($app . '/views');
+
+        $result = $this->runConsole($app);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testSymlinkedAppResolvesCanonically(): void
+    {
+        $app = $this->temporaryDirectory . '/real-app';
+        $link = $this->temporaryDirectory . '/linked-app';
+        $this->createApp($app);
+
+        if (!function_exists('symlink') || !@symlink($app, $link)) {
+            $this->markTestSkipped('Symbolic links are not available');
+        }
+
+        $result = $this->runConsole($link);
+
+        $this->assertSuccessfulPath($result, $app);
+    }
+
+    public function testExistingInvalidDirectoryReportsAcceptedPathForms(): void
+    {
+        $invalid = $this->temporaryDirectory . '/invalid';
+        mkdir($invalid);
+
+        $result = $this->runConsole($invalid);
+
+        $this->assertNotSame(0, $result['status']);
+        $this->assertStringContainsString(
+            '--path puede apuntar al directorio de la aplicación o a la raíz del proyecto KumbiaPHP',
+            $result['stderr']
+        );
+    }
+
+    public function testNonexistentExplicitPathKeepsInvalidPathError(): void
+    {
+        $invalid = $this->temporaryDirectory . '/does-not-exist';
+
+        $result = $this->runConsole($invalid);
+
+        $this->assertNotSame(0, $result['status']);
+        $this->assertStringContainsString("La ruta \"$invalid\" es invalida", $result['stderr']);
+    }
+
+    private function createApp(string $app, string $configFile = 'config.php'): void
+    {
+        mkdir($app . '/config', 0777, true);
+        mkdir($app . '/extensions/console', 0777, true);
+
+        $config = $configFile === 'config.php'
+            ? "<?php\nreturn ['application' => ['production' => false]];\n"
+            : "[application]\nproduction = 0\n";
+        file_put_contents($app . "/config/$configFile", $config);
+        file_put_contents(
+            $app . '/extensions/console/path_probe_console.php',
+            "<?php\nclass PathProbeConsole\n{\n    public function main()\n    {\n        echo APP_PATH;\n    }\n}\n"
+        );
+    }
+
+    private function runConsole(?string $path, ?string $cwd = null): array
+    {
+        $command = [PHP_BINARY, $this->consoleEntrypoint, 'path_probe', 'main'];
+        if ($path !== null) {
+            $command[] = "--path=$path";
+        }
+
+        $process = proc_open(
+            $command,
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            $cwd ?? $this->temporaryDirectory
+        );
+        if (!is_resource($process)) {
+            $this->fail('Unable to start the console subprocess');
+        }
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return [
+            'status' => proc_close($process),
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+        ];
+    }
+
+    private function assertSuccessfulPath(array $result, string $app): void
+    {
+        $this->assertSame('', $result['stderr']);
+        $this->assertSame(0, $result['status']);
+        $this->assertSame(realpath($app) . DIRECTORY_SEPARATOR, $result['stdout']);
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            unlink($path);
+
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+
+        foreach (scandir($path) as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeDirectory($path . DIRECTORY_SEPARATOR . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -98,6 +98,22 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         ];
     }
 
+    public function testConfiguredProductionValueIsPreserved(): void
+    {
+        $app = $this->temporaryDirectory . '/configured-production-app';
+        $this->createApp($app);
+        file_put_contents(
+            $app . '/config/config.php',
+            "<?php\nreturn ['application' => ['production' => 'configured']];\n"
+        );
+
+        $result = $this->runConsole($app, null, 'production');
+
+        $this->assertSame('', $result['stderr']);
+        $this->assertSame(0, $result['status']);
+        $this->assertSame('configured', $result['stdout']);
+    }
+
     /**
      * @dataProvider trailingSeparatorProvider
      */
@@ -178,18 +194,18 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         mkdir($app . '/extensions/console', 0777, true);
 
         $config = $configFile === 'config.php'
-            ? "<?php\nreturn ['application' => ['production' => false]];\n"
-            : "[application]\nproduction = 0\n";
+            ? "<?php\nreturn ['application' => []];\n"
+            : "[application]\n";
         file_put_contents($app . "/config/$configFile", $config);
         file_put_contents(
             $app . '/extensions/console/path_probe_console.php',
-            "<?php\nclass PathProbeConsole\n{\n    public function main()\n    {\n        echo APP_PATH;\n    }\n}\n"
+            "<?php\nclass PathProbeConsole\n{\n    public function main()\n    {\n        echo APP_PATH;\n    }\n\n    public function production()\n    {\n        echo PRODUCTION;\n    }\n}\n"
         );
     }
 
-    private function runConsole(?string $path, ?string $cwd = null): array
+    private function runConsole(?string $path, ?string $cwd = null, string $command = 'main'): array
     {
-        $command = [PHP_BINARY, $this->consoleEntrypoint, 'path_probe', 'main'];
+        $command = [PHP_BINARY, $this->consoleEntrypoint, 'path_probe', $command];
         if ($path !== null) {
             $command[] = "--path=$path";
         }


### PR DESCRIPTION
## Summary

Merge the reviewed `dev` updates into `master`, improving console reliability and expanding regression coverage for console and CSS helper behavior.

## Included work

- #407 — Improve console application path resolution and provide clearer handling for invalid directories.
- #408 — Expand CSS helper coverage for dependencies, ordering, deduplication, idempotency, and subdirectory paths.
- #420 — Use a safe default when `application.production` is missing while preserving explicitly configured values.

## Changes

| File | Change |
|------|--------|
| `core/kumbia/console.php` | Improve application path resolution and invalid-directory handling, and safely default a missing production setting. (45 additions, 4 deletions) |
| `core/tests/classes/extensions/helpers/CssTest.php` | Add coverage for CSS dependencies, ordering, deduplication, idempotency, and subdirectory paths. (120 additions) |
| `core/tests/classes/kumbia/ConsoleTest.php` | Add regression coverage for console path resolution, invalid directories, and production configuration behavior. (265 additions) |

## Verification

Verified at commit `86a58d49fbe1cc3ffdae582819119baf6cab1c21` with PHP 8.4.23 and PHPUnit 9.6.35.

- `vendor/bin/phpunit --configuration core/phpunit.xml.dist` — PASS: 144 tests, 255 assertions in 2.129s; 0 warnings, deprecations, errors, failures, or skips.
- `vendor/bin/phpunit --configuration default/app/phpunit.xml.dist` — PASS: 1 test, 2 assertions in 0.028s; 0 warnings, deprecations, errors, failures, or skips.