### PR TITLE
chore: update copyright references to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2005 - 2023, KumbiaPHP Team www.kumbiaphp.com
+Copyright (c) 2005 - 2026, KumbiaPHP Team www.kumbiaphp.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/core/console/cache_console.php
+++ b/core/console/cache_console.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Console
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 // carga libreria para manejo de cache

--- a/core/console/controller_console.php
+++ b/core/console/controller_console.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Console
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/console/kumbia.php
+++ b/core/console/kumbia.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Console
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/console/model_console.php
+++ b/core/console/model_console.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Console
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/extensions/helpers/ajax.php
+++ b/core/extensions/helpers/ajax.php
@@ -10,7 +10,7 @@
  * @category   KumbiaPHP
  * @package    Helpers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/extensions/helpers/css.php
+++ b/core/extensions/helpers/css.php
@@ -10,7 +10,7 @@
  * @category   KumbiaPHP
  * @package    Helpers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/extensions/helpers/flash.php
+++ b/core/extensions/helpers/flash.php
@@ -10,7 +10,7 @@
  * @category   KumbiaPHP
  * @package    Helpers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/extensions/helpers/form.php
+++ b/core/extensions/helpers/form.php
@@ -11,7 +11,7 @@
  * @category   KumbiaPHP
  * @package    Helpers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/extensions/helpers/html.php
+++ b/core/extensions/helpers/html.php
@@ -10,7 +10,7 @@
  * @category   KumbiaPHP
  * @package    Helpers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/extensions/helpers/js.php
+++ b/core/extensions/helpers/js.php
@@ -10,7 +10,7 @@
  * @category   KumbiaPHP
  * @package    Helpers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/extensions/helpers/model_form.php
+++ b/core/extensions/helpers/model_form.php
@@ -10,7 +10,7 @@
  * @category   KumbiaPHP
  * @package    Helpers
  *
- * @copyright  Copyright (c) 2005 - 2024 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/extensions/helpers/tag.php
+++ b/core/extensions/helpers/tag.php
@@ -10,7 +10,7 @@
  * @category   KumbiaPHP
  * @package    Helpers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/autoload.php
+++ b/core/kumbia/autoload.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/bootstrap.php
+++ b/core/kumbia/bootstrap.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/config.php
+++ b/core/kumbia/config.php
@@ -9,7 +9,7 @@
  *
  * @category   Config
  *
- * @copyright  Copyright (c) 2005 - 2024 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/console.php
+++ b/core/kumbia/console.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/kumbia/controller.php
+++ b/core/kumbia/controller.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Controller
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/kumbia_exception.php
+++ b/core/kumbia/kumbia_exception.php
@@ -9,7 +9,7 @@
  *
  * @category   Kumbia
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/kumbia_facade.php
+++ b/core/kumbia/kumbia_facade.php
@@ -9,7 +9,7 @@
  *
  * @category   Kumbia
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/kumbia_rest.php
+++ b/core/kumbia/kumbia_rest.php
@@ -9,7 +9,7 @@
  *
  * @category   Kumbia
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 require_once __DIR__.'/controller.php';

--- a/core/kumbia/kumbia_router.php
+++ b/core/kumbia/kumbia_router.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    KumbiaRouter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/kumbia_version.php
+++ b/core/kumbia/kumbia_version.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/kumbia_view.php
+++ b/core/kumbia/kumbia_view.php
@@ -9,7 +9,7 @@
  *
  * @category   View
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/load.php
+++ b/core/kumbia/load.php
@@ -9,7 +9,7 @@
  *
  * @category   Kumbia
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/router.php
+++ b/core/kumbia/router.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Router
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/static_router.php
+++ b/core/kumbia/static_router.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Router
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/util.php
+++ b/core/kumbia/util.php
@@ -9,7 +9,7 @@
  *
  * @category   Kumbia
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/kumbia/workerboot.php
+++ b/core/kumbia/workerboot.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/acl/acl.php
+++ b/core/libs/acl/acl.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Acl
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/acl/resource/resource.php
+++ b/core/libs/acl/resource/resource.php
@@ -11,7 +11,7 @@
  * @package    Acl
  * @subpackage AclResource
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/acl/role/role.php
+++ b/core/libs/acl/role/role.php
@@ -11,7 +11,7 @@
  * @package    Acl
  * @subpackage AclRole
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/acl2/acl2.php
+++ b/core/libs/acl2/acl2.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Acl
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/acl2/adapters/simple_acl.php
+++ b/core/libs/acl2/adapters/simple_acl.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Acl
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/auth/adapters/digest_auth.php
+++ b/core/libs/auth/adapters/digest_auth.php
@@ -11,7 +11,7 @@
  * @package    Auth
  * @subpackage Adapters
  * 
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/auth/adapters/kerberos5_auth.php
+++ b/core/libs/auth/adapters/kerberos5_auth.php
@@ -11,7 +11,7 @@
  * @package    Auth
  * @subpackage Adapters
  * 
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/auth/adapters/model_auth.php
+++ b/core/libs/auth/adapters/model_auth.php
@@ -11,7 +11,7 @@
  * @package    Auth
  * @subpackage Adapters
  * 
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/auth/adapters/radius_auth.php
+++ b/core/libs/auth/adapters/radius_auth.php
@@ -11,7 +11,7 @@
  * @package    Auth
  * @subpackage Adapters
  * 
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/auth/auth.php
+++ b/core/libs/auth/auth.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Auth
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/auth/auth_interface.php
+++ b/core/libs/auth/auth_interface.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Auth
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/auth2/adapters/model_auth.php
+++ b/core/libs/auth2/adapters/model_auth.php
@@ -11,7 +11,7 @@
  * @package    Auth
  * @subpackage Adapters
  * 
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/auth2/auth2.php
+++ b/core/libs/auth2/auth2.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Auth
  * 
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/benchmark/benchmark.php
+++ b/core/libs/benchmark/benchmark.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/cache/cache.php
+++ b/core/libs/cache/cache.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Cache
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/cache/drivers/APC_cache.php
+++ b/core/libs/cache/drivers/APC_cache.php
@@ -11,7 +11,7 @@
  * @package    Cache
  * @subpackage Drivers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/cache/drivers/file_cache.php
+++ b/core/libs/cache/drivers/file_cache.php
@@ -11,7 +11,7 @@
  * @package    Cache
  * @subpackage Drivers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/cache/drivers/nixfile_cache.php
+++ b/core/libs/cache/drivers/nixfile_cache.php
@@ -11,7 +11,7 @@
  * @package    Cache
  * @subpackage Drivers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/cache/drivers/sqlite_cache.php
+++ b/core/libs/cache/drivers/sqlite_cache.php
@@ -11,7 +11,7 @@
  * @package    Cache
  * @subpackage Drivers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/date/date.php
+++ b/core/libs/date/date.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Date
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/adapters/firebird.php
+++ b/core/libs/db/adapters/firebird.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/adapters/informix.php
+++ b/core/libs/db/adapters/informix.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/adapters/mssql.php
+++ b/core/libs/db/adapters/mssql.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/adapters/mysql.php
+++ b/core/libs/db/adapters/mysql.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/adapters/oracle.php
+++ b/core/libs/db/adapters/oracle.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/adapters/pdo.php
+++ b/core/libs/db/adapters/pdo.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/adapters/pdo/access.php
+++ b/core/libs/db/adapters/pdo/access.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage PDO Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/adapters/pdo/informix.php
+++ b/core/libs/db/adapters/pdo/informix.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage PDO Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/adapters/pdo/interface.php
+++ b/core/libs/db/adapters/pdo/interface.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage PDO Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/adapters/pdo/mssql.php
+++ b/core/libs/db/adapters/pdo/mssql.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage PDO Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/adapters/pdo/mysql.php
+++ b/core/libs/db/adapters/pdo/mysql.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage PDO Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/adapters/pdo/oracle.php
+++ b/core/libs/db/adapters/pdo/oracle.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage PDO Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/adapters/pdo/pgsql.php
+++ b/core/libs/db/adapters/pdo/pgsql.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage PDO Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/adapters/pdo/sqlite.php
+++ b/core/libs/db/adapters/pdo/sqlite.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage PDO Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/adapters/pgsql.php
+++ b/core/libs/db/adapters/pgsql.php
@@ -12,7 +12,7 @@
  * @package    Db
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/adapters/sqlite.php
+++ b/core/libs/db/adapters/sqlite.php
@@ -11,7 +11,7 @@
  * @package    Db
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/db.php
+++ b/core/libs/db/db.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Db
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/db/db_base.php
+++ b/core/libs/db/db_base.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Db
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/db/db_base_interface.php
+++ b/core/libs/db/db_base_interface.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Db
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/event/event.php
+++ b/core/libs/event/event.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Event
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/event/hook.php
+++ b/core/libs/event/hook.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Event
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/file_util/file_util.php
+++ b/core/libs/file_util/file_util.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/addslashes_filter.php
+++ b/core/libs/filter/base_filter/addslashes_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/alnum_filter.php
+++ b/core/libs/filter/base_filter/alnum_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/alpha_filter.php
+++ b/core/libs/filter/base_filter/alpha_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/date_filter.php
+++ b/core/libs/filter/base_filter/date_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/digits_filter.php
+++ b/core/libs/filter/base_filter/digits_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/htmlentities_filter.php
+++ b/core/libs/filter/base_filter/htmlentities_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/htmlspecialchars_filter.php
+++ b/core/libs/filter/base_filter/htmlspecialchars_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/int_filter.php
+++ b/core/libs/filter/base_filter/int_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/ipv4_filter.php
+++ b/core/libs/filter/base_filter/ipv4_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/lower_filter.php
+++ b/core/libs/filter/base_filter/lower_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/md5_filter.php
+++ b/core/libs/filter/base_filter/md5_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/nl2br_filter.php
+++ b/core/libs/filter/base_filter/nl2br_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/numeric_filter.php
+++ b/core/libs/filter/base_filter/numeric_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/stripslashes_filter.php
+++ b/core/libs/filter/base_filter/stripslashes_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/stripspace_filter.php
+++ b/core/libs/filter/base_filter/stripspace_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/striptags_filter.php
+++ b/core/libs/filter/base_filter/striptags_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/trim_filter.php
+++ b/core/libs/filter/base_filter/trim_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/base_filter/upper_filter.php
+++ b/core/libs/filter/base_filter/upper_filter.php
@@ -11,7 +11,7 @@
  * @package    Filter
  * @subpackage BaseFilter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/filter/filter.php
+++ b/core/libs/filter/filter.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Filter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/filter/filter_interface.php
+++ b/core/libs/filter/filter_interface.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Filter
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/i18n/i18n.php
+++ b/core/libs/i18n/i18n.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    I18n
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/input/input.php
+++ b/core/libs/input/input.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Input
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
  

--- a/core/libs/kumbia_active_record/behaviors/paginate.php
+++ b/core/libs/kumbia_active_record/behaviors/paginate.php
@@ -11,7 +11,7 @@
  * @package    ActiveRecord
  * @subpackage Behaviors
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/kumbia_active_record/kumbia_active_record.php
+++ b/core/libs/kumbia_active_record/kumbia_active_record.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    ActiveRecord
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/kumbia_auth/kumbia_auth.php
+++ b/core/libs/kumbia_auth/kumbia_auth.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    KumbiaAuth
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/kumbia_auth_base/kumbia_auth_base.php
+++ b/core/libs/kumbia_auth_base/kumbia_auth_base.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    KumbiaAuth
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/logger/logger.php
+++ b/core/libs/logger/logger.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Logger
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/redirect/redirect.php
+++ b/core/libs/redirect/redirect.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Redirect
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 /**

--- a/core/libs/registry/registry.php
+++ b/core/libs/registry/registry.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Security
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/rest/rest.php
+++ b/core/libs/rest/rest.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Rest
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  * 
  * @deprecated Deprecated since version 1.0, Use RestController

--- a/core/libs/security/security.php
+++ b/core/libs/security/security.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Security
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/session/session.php
+++ b/core/libs/session/session.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Session
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/upload/adapters/file_upload.php
+++ b/core/libs/upload/adapters/file_upload.php
@@ -11,7 +11,7 @@
  * @package    Upload
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/upload/adapters/image_upload.php
+++ b/core/libs/upload/adapters/image_upload.php
@@ -11,7 +11,7 @@
  * @package    Upload
  * @subpackage Adapters
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/upload/upload.php
+++ b/core/libs/upload/upload.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Upload
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/validate/validate.php
+++ b/core/libs/validate/validate.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Validate
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/libs/validate/validations.php
+++ b/core/libs/validate/validations.php
@@ -10,7 +10,7 @@
  * @category   Kumbia
  * @package    Validate
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/tests/bootstrap.php
+++ b/core/tests/bootstrap.php
@@ -10,7 +10,7 @@
  * @category   Test
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/tests/classes/extensions/helpers/FlashTest.php
+++ b/core/tests/classes/extensions/helpers/FlashTest.php
@@ -10,7 +10,7 @@
  * @category   Test
  * @package    Flash
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -10,7 +10,7 @@
  * @category   Test
  * @package    Html
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -10,7 +10,7 @@
  * @category   Test
  * @package    Tag
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -10,7 +10,7 @@
  * @category   Test
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -14,7 +14,7 @@
  *
  * @category   Kumbia
  * @package    Session
- * @copyright  Copyright (c) 2005 - 2017 Kumbia Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 Kumbia Team (http://www.kumbiaphp.com)
  * @license    http://wiki.kumbiaphp.com/Licencia     New BSD License
  */
 

--- a/core/tests/classes/libs/session/SessionTest.php
+++ b/core/tests/classes/libs/session/SessionTest.php
@@ -10,7 +10,7 @@
  * @category   Test
  * @package    Session
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/views/partials/paginators/classic.phtml
+++ b/core/views/partials/paginators/classic.phtml
@@ -19,7 +19,7 @@
  * @package     Partials
  * @subpackage  Paginators
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/views/partials/paginators/digg.phtml
+++ b/core/views/partials/paginators/digg.phtml
@@ -19,7 +19,7 @@
  * @package     Partials
  * @subpackage  Paginators
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/views/partials/paginators/extended.phtml
+++ b/core/views/partials/paginators/extended.phtml
@@ -18,7 +18,7 @@
  * @package     Partials
  * @subpackage  Paginators
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/views/partials/paginators/punbb.phtml
+++ b/core/views/partials/paginators/punbb.phtml
@@ -19,7 +19,7 @@
  * @package     Partials
  * @subpackage  Paginators
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/core/views/partials/paginators/simple.phtml
+++ b/core/views/partials/paginators/simple.phtml
@@ -18,7 +18,7 @@
  * @package     Partials
  * @subpackage  Paginators
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/default/app/tests/Controller/PagesControllerTest.php
+++ b/default/app/tests/Controller/PagesControllerTest.php
@@ -10,7 +10,7 @@
  * @category   Kumbia Tests
  * @package    Controller
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/default/app/tests/KumbiaTestTrait.php
+++ b/default/app/tests/KumbiaTestTrait.php
@@ -10,7 +10,7 @@
  * @category   Kumbia Tests
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/default/app/tests/bootstrap.php
+++ b/default/app/tests/bootstrap.php
@@ -11,7 +11,7 @@
  * @category   Kumbia Tests
  * @package    Core
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/default/index.php
+++ b/default/index.php
@@ -12,7 +12,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@kumbiaphp.com so we can send you a copy immediately. 
  *  
- * @copyright  Copyright (c) 2005 - 2023 Kumbia Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 Kumbia Team (http://www.kumbiaphp.com)
  * @license    http://wiki.kumbiaphp.com/Licencia     New BSD License
  */
 

--- a/default/public/index.php
+++ b/default/public/index.php
@@ -7,7 +7,7 @@
  * This source file is subject to the new BSD license that is bundled
  * with this package in the file LICENSE.
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 

--- a/default/public/javascript/jquery/jquery.kumbiaphp.js
+++ b/default/public/javascript/jquery/jquery.kumbiaphp.js
@@ -8,7 +8,7 @@
  *
  * Plugin para jQuery que incluye los callbacks basicos para los Helpers
  *
- * @copyright  Copyright (c) 2005 - 2023 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 


### PR DESCRIPTION
## Summary

- Updates 126 outdated KumbiaPHP copyright references to end in 2026.
- Preserves historical starting years and copyright owners.
- Leaves dynamic year references and third-party notices unchanged.

## Changes

| Area | Updated references |
| --- | ---: |
| `LICENSE` | 1 |
| `core/` | 119 |
| `default/` | 6 |
| **Total** | **126** |

## Verification

- Confirmed that no static KumbiaPHP copyright reference ending before 2026 remains.
- Confirmed exactly one intended replacement in each affected file.
- `git diff --check` passed.
- Runtime tests were not run because this change only updates copyright text and does not affect executable behavior.