### PR TITLE
Merge dev into master

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -51,6 +51,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: composer
           extensions: gd, sqlite3, opcache
+          ini-values: opcache.enable_cli=1
           coverage: none
         env:
           update: true

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
         phpunit-versions: ['latest']
 
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP, with composer
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer
         uses: shivammathur/setup-php@v2
@@ -60,7 +60,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
         phpunit-versions: ['latest']
 
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer
-          extensions: gd, sqlite3
+          extensions: gd, sqlite3, opcache
           coverage: none
         env:
           update: true

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "license": "BSD-3-Clause",
     "name": "kumbia/framework",
     "require": {
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9 || ^10 || ^11 || ^12 || ^13",
+        "phpunit/phpunit": "^10 || ^11 || ^12 || ^13",
         "mockery/mockery": "^1"
     },
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -22,3 +22,4 @@
     },
     "type": "project"
 }
+

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": ">=8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9 || ^10 || ^11 || ^12 || ^13",
         "mockery/mockery": "^1"
     },
     "support": {

--- a/core/extensions/helpers/form.php
+++ b/core/extensions/helpers/form.php
@@ -99,10 +99,11 @@ class Form
      */
     protected static function getFromModel(array $formField)
     {
-        if (!isset($formField[1])) {
-            return null;
-        }
         $form = View::getVar($formField[0]);
+
+        if (!isset($formField[1])) {
+            return is_scalar($form) || is_null($form) ? $form : null;
+        }
         if (is_scalar($form) || is_null($form)) {
             return $form;
         }

--- a/core/extensions/helpers/form.php
+++ b/core/extensions/helpers/form.php
@@ -60,11 +60,11 @@ class Form
         if (Input::hasPost($field)) {
             $value = $is_check ?
                 Input::post($field) == $value : Input::post($field);
-        } elseif ($is_check) {
-            $value = $check;
-        } elseif ($tmp_val = self::getFromModel($formField)) {
+        } elseif (($tmp_val = self::getFromModel($formField)) !== null) {
             // Autocarga de datos
             $value = $is_check ? $tmp_val == $value : $tmp_val;
+        } elseif ($is_check) {
+            $value = $check;
         }
         // Filtrar caracteres especiales
         if (!$is_check && $value !== null && $filter) {
@@ -99,6 +99,9 @@ class Form
      */
     protected static function getFromModel(array $formField)
     {
+        if (!isset($formField[1])) {
+            return null;
+        }
         $form = View::getVar($formField[0]);
         if (is_scalar($form) || is_null($form)) {
             return $form;

--- a/core/extensions/helpers/form.php
+++ b/core/extensions/helpers/form.php
@@ -101,11 +101,11 @@ class Form
     {
         $form = View::getVar($formField[0]);
 
-        if (!isset($formField[1])) {
-            return is_scalar($form) || is_null($form) ? $form : null;
-        }
         if (is_scalar($form) || is_null($form)) {
             return $form;
+        }
+        if (!isset($formField[1])) {
+            return null;
         }
         $form = (object) $form;
 

--- a/core/libs/db/adapters/pdo/pgsql.php
+++ b/core/libs/db/adapters/pdo/pgsql.php
@@ -216,13 +216,18 @@ class DbPdoPgSQL extends DbPDO
      */
     public function describe_table($table, $schema = '')
     {
+        if ($schema == '') {
+            $schema = 'public';
+        }
+        $schema = str_replace("'", "''", $schema);
         $describe = $this->fetch_all("SELECT a.attname AS Field, t.typname AS Type,
                 CASE WHEN attnotnull=false THEN 'YES' ELSE 'NO' END AS Null,
                 CASE WHEN (select cc.contype FROM pg_catalog.pg_constraint cc WHERE
                 cc.conrelid = c.oid AND cc.conkey[1] = a.attnum)='p' THEN 'PRI' ELSE ''
                 END AS Key, CASE WHEN atthasdef=true THEN TRUE ELSE NULL END AS Default
                 FROM pg_catalog.pg_class c, pg_catalog.pg_attribute a,
-                pg_catalog.pg_type t WHERE c.relname = '$table' AND c.oid = a.attrelid
+                pg_catalog.pg_type t, pg_catalog.pg_namespace n WHERE c.relname = '$table' AND n.nspname = '$schema'
+                AND n.oid = c.relnamespace AND c.oid = a.attrelid
                 AND a.attnum > 0 AND t.oid = a.atttypid order by a.attnum");
         $final_describe = [];
         foreach ($describe as $field) {

--- a/core/libs/db/adapters/pdo/pgsql.php
+++ b/core/libs/db/adapters/pdo/pgsql.php
@@ -219,7 +219,6 @@ class DbPdoPgSQL extends DbPDO
         if ($schema == '') {
             $schema = 'public';
         }
-        $schema = str_replace("'", "''", $schema);
         $describe = $this->fetch_all("SELECT a.attname AS Field, t.typname AS Type,
                 CASE WHEN attnotnull=false THEN 'YES' ELSE 'NO' END AS Null,
                 CASE WHEN (select cc.contype FROM pg_catalog.pg_constraint cc WHERE

--- a/core/libs/db/adapters/pdo/pgsql.php
+++ b/core/libs/db/adapters/pdo/pgsql.php
@@ -225,7 +225,7 @@ class DbPdoPgSQL extends DbPDO
         $describe = $this->fetch_all("SELECT a.attname AS Field, t.typname AS Type,
                 CASE WHEN attnotnull=false THEN 'YES' ELSE 'NO' END AS Null,
                 CASE WHEN (select cc.contype FROM pg_catalog.pg_constraint cc WHERE
-                cc.conrelid = c.oid AND cc.conkey[1] = a.attnum)='p' THEN 'PRI' ELSE ''
+                cc.conrelid = c.oid AND cc.conkey[1] = a.attnum limit 1)='p' THEN 'PRI' ELSE ''
                 END AS Key, CASE WHEN atthasdef=true THEN TRUE ELSE NULL END AS Default
                 FROM pg_catalog.pg_class c, pg_catalog.pg_attribute a,
                 pg_catalog.pg_type t, pg_catalog.pg_namespace n WHERE c.relname = '$table' AND n.nspname = '$schema'

--- a/core/libs/db/adapters/pdo/pgsql.php
+++ b/core/libs/db/adapters/pdo/pgsql.php
@@ -216,8 +216,11 @@ class DbPdoPgSQL extends DbPDO
      */
     public function describe_table($table, $schema = '')
     {
-        if ($schema == '') {
+        $table = addslashes($table);
+        if ($schema === null || $schema === '') {
             $schema = 'public';
+        } else {
+            $schema = addslashes($schema);
         }
         $describe = $this->fetch_all("SELECT a.attname AS Field, t.typname AS Type,
                 CASE WHEN attnotnull=false THEN 'YES' ELSE 'NO' END AS Null,

--- a/core/libs/db/adapters/pgsql.php
+++ b/core/libs/db/adapters/pgsql.php
@@ -473,13 +473,18 @@ class DbPgSQL extends DbBase implements DbBaseInterface
      */
     public function describe_table($table, $schema = '')
     {
+        if ($schema === null || $schema === '') {
+            $schema = 'public';
+        }
+        $schema = str_replace("'", "''", $schema);
         $describe = $this->fetch_all("SELECT a.attname AS Field, t.typname AS Type,
                 CASE WHEN attnotnull=false THEN 'YES' ELSE 'NO' END AS Null,
                 CASE WHEN (select cc.contype FROM pg_catalog.pg_constraint cc WHERE
                 cc.conrelid = c.oid AND cc.conkey[1] = a.attnum limit 1)='p' THEN 'PRI' ELSE ''
                 END AS Key, CASE WHEN atthasdef=true THEN TRUE ELSE NULL END AS Default
                 FROM pg_catalog.pg_class c, pg_catalog.pg_attribute a,
-                pg_catalog.pg_type t WHERE c.relname = '$table' AND c.oid = a.attrelid
+                pg_catalog.pg_type t, pg_catalog.pg_namespace n WHERE c.relname = '$table'
+                AND n.oid = c.relnamespace AND n.nspname = '$schema' AND c.oid = a.attrelid
                 AND a.attnum > 0 AND t.oid = a.atttypid order by a.attnum");
         $final_describe = array();
         foreach ($describe as $field) {

--- a/core/libs/db/adapters/pgsql.php
+++ b/core/libs/db/adapters/pgsql.php
@@ -476,7 +476,6 @@ class DbPgSQL extends DbBase implements DbBaseInterface
         if ($schema === null || $schema === '') {
             $schema = 'public';
         }
-        $schema = str_replace("'", "''", $schema);
         $describe = $this->fetch_all("SELECT a.attname AS Field, t.typname AS Type,
                 CASE WHEN attnotnull=false THEN 'YES' ELSE 'NO' END AS Null,
                 CASE WHEN (select cc.contype FROM pg_catalog.pg_constraint cc WHERE

--- a/core/libs/db/adapters/pgsql.php
+++ b/core/libs/db/adapters/pgsql.php
@@ -473,8 +473,11 @@ class DbPgSQL extends DbBase implements DbBaseInterface
      */
     public function describe_table($table, $schema = '')
     {
+        $table = addslashes($table);
         if ($schema === null || $schema === '') {
             $schema = 'public';
+        } else {
+            $schema = addslashes($schema);
         }
         $describe = $this->fetch_all("SELECT a.attname AS Field, t.typname AS Type,
                 CASE WHEN attnotnull=false THEN 'YES' ELSE 'NO' END AS Null,

--- a/core/libs/input/input.php
+++ b/core/libs/input/input.php
@@ -110,7 +110,15 @@ class Input
      */
     public static function hasPost($var)
     {
-        return (bool) self::post($var);
+        $value = $_POST;
+        foreach (explode('.', $var) as $key) {
+            if (!is_array($value) || !array_key_exists($key, $value)) {
+                return false;
+            }
+            $value = $value[$key];
+        }
+
+        return true;
     }
 
     /**

--- a/core/phpunit.xml.dist
+++ b/core/phpunit.xml.dist
@@ -10,8 +10,6 @@
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
-        <ini name="opcache.enable_cli" value="1"/>
     </php>
 
     <testsuites>

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -152,7 +152,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($modelValue, $actual);
     }
 
-    #[DataProvider('onePartNonScalarViewValueProvider')]
+    #[DataProvider('onePartNonScalarValueProvider')]
     public function testOnePartFieldIgnoresObjectAndArrayViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * KumbiaPHP web & app Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.
+ *
+ * @category   Test
+ * @package    Form
+ *
+ * @copyright  Copyright (c) 2005 - 2026 KumbiaPHP Team (http://www.kumbiaphp.com)
+ * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
+ */
+
+require_once CORE_PATH.'kumbia/kumbia_view.php';
+
+if (!class_exists('View', false)) {
+    class View extends KumbiaView
+    {
+    }
+}
+
+class FormTest extends PHPUnit\Framework\TestCase
+{
+    private $originalPost;
+    private $originalRadios;
+    private $originalViewData;
+    private $radios;
+    private $viewData;
+
+    protected function setUp(): void
+    {
+        $this->originalPost = $_POST;
+        $this->radios = new ReflectionProperty(Form::class, 'radios');
+        $this->radios->setAccessible(true);
+        $this->originalRadios = $this->radios->getValue();
+        $this->viewData = new ReflectionProperty(View::class, '_controller');
+        $this->viewData->setAccessible(true);
+        $this->originalViewData = $this->viewData->getValue();
+        $this->radios->setValue(null, []);
+        $_POST = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST = $this->originalPost;
+        $this->radios->setValue(null, $this->originalRadios);
+        $this->viewData->setValue(null, $this->originalViewData);
+    }
+
+    public function checkedFieldProvider()
+    {
+        $cases = [
+            [1, false, null, 1, false, true],
+            [2, false, null, 1, true, false],
+            [0, false, null, 0, false, true],
+            ['0', false, null, '0', false, true],
+            [false, false, null, 0, false, true],
+            [null, false, null, 1, false, false],
+            [null, false, null, 1, true, true],
+            [2, true, 1, 1, false, true],
+            [1, true, 2, 1, true, false],
+            [1, true, '0', '0', false, true],
+        ];
+        $data = [];
+        foreach (['check', 'radio'] as $helper) {
+            foreach ($cases as $case) {
+                $data[] = array_merge([$helper], $case);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider checkedFieldProvider
+     */
+    public function testCheckedFieldsUsePostThenModelThenFallback(
+        $helper,
+        $modelValue,
+        $hasPost,
+        $postValue,
+        $checkValue,
+        $fallback,
+        $expected
+    ) {
+        $this->setModelValue($modelValue);
+        if ($hasPost) {
+            $_POST = ['record' => ['flag' => $postValue]];
+        }
+
+        $html = Form::$helper('record.flag', $checkValue, '', $fallback);
+
+        $this->assertSame($expected, str_contains($html, 'checked="checked"'));
+    }
+
+    public function genericModelValueProvider()
+    {
+        return [
+            [0],
+            ['0'],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider genericModelValueProvider
+     */
+    public function testGenericFieldPreservesFalsyModelValues($modelValue)
+    {
+        $this->setModelValue($modelValue);
+
+        [, , $actual] = Form::getFieldData('record.flag', 'fallback', false);
+
+        $this->assertSame($modelValue, $actual);
+    }
+
+    public function testGenericFieldUsesPostedStringZero()
+    {
+        $this->setModelValue('model');
+        $_POST = ['record' => ['flag' => '0']];
+
+        [, , $actual] = Form::getFieldData('record.flag', 'fallback', false);
+
+        $this->assertSame('0', $actual);
+    }
+
+    public function testOnePartCheckedFieldUsesFallbackWithoutModelProperty()
+    {
+        $this->viewData->setValue(null, ['record' => (object) ['flag' => 1]]);
+
+        [, , $actual] = Form::getFieldDataCheck('record', 1, true);
+
+        $this->assertTrue($actual);
+    }
+
+    public function testRadioIdsStartFromZeroForEachTest()
+    {
+        $this->setModelValue(1);
+
+        $first = Form::radio('record.flag', 1);
+        $second = Form::radio('record.flag', 1);
+
+        $this->assertStringContainsString('id="record_flag0"', $first);
+        $this->assertStringContainsString('id="record_flag1"', $second);
+    }
+
+    private function setModelValue($value)
+    {
+        $this->viewData->setValue(null, ['record' => (object) ['flag' => $value]]);
+    }
+}

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -152,7 +152,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($modelValue, $actual);
     }
 
-    #[DataProvider('onePartScalarViewValueProvider')]
+    #[DataProvider('onePartNonScalarViewValueProvider')]
     public function testOnePartFieldIgnoresObjectAndArrayViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -50,7 +50,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->viewData->setValue(null, $this->originalViewData);
     }
 
-    public function checkedFieldProvider()
+    public static function checkedFieldProvider()
     {
         $cases = [
             [1, false, null, 1, false, true],
@@ -96,7 +96,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, str_contains($html, 'checked="checked"'));
     }
 
-    public function twoPartViewValueProvider()
+    public static function twoPartViewValueProvider()
     {
         return [
             'object property' => [true, (object) ['flag' => 'object value'], 'object value'],
@@ -134,7 +134,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('0', $actual);
     }
 
-    public function onePartScalarViewValueProvider()
+    public static function onePartScalarViewValueProvider()
     {
         return [
             ['active'],
@@ -168,7 +168,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('fallback', $actual);
     }
 
-    public function onePartNonScalarValueProvider()
+    public static function onePartNonScalarValueProvider()
     {
         return [
             [(object) ['value' => 'ignored']],

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -96,25 +96,32 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, str_contains($html, 'checked="checked"'));
     }
 
-    public function genericModelValueProvider()
+    public function twoPartViewValueProvider()
     {
         return [
-            [0],
-            ['0'],
-            [false],
+            'object property' => [true, (object) ['flag' => 'object value'], 'object value'],
+            'array property' => [true, ['flag' => 'array value'], 'array value'],
+            'scalar string zero' => [true, '0', '0'],
+            'scalar integer zero' => [true, 0, 0],
+            'scalar false' => [true, false, false],
+            'null view value' => [true, null, 'fallback'],
+            'missing view value' => [false, null, 'fallback'],
+            'null property' => [true, (object) ['flag' => null], 'fallback'],
+            'missing object property' => [true, (object) [], 'fallback'],
+            'missing array property' => [true, [], 'fallback'],
         ];
     }
 
     /**
-     * @dataProvider genericModelValueProvider
+     * @dataProvider twoPartViewValueProvider
      */
-    public function testGenericFieldPreservesFalsyModelValues($modelValue)
+    public function testTwoPartFieldUsesViewValueOrFallback($hasViewValue, $viewValue, $expected)
     {
-        $this->setModelValue($modelValue);
+        $this->viewData->setValue(null, $hasViewValue ? ['record' => $viewValue] : []);
 
         [, , $actual] = Form::getFieldData('record.flag', 'fallback', false);
 
-        $this->assertSame($modelValue, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testGenericFieldUsesPostedStringZero()
@@ -127,9 +134,10 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('0', $actual);
     }
 
-    public function onePartModelValueProvider()
+    public function onePartScalarViewValueProvider()
     {
         return [
+            ['active'],
             ['0'],
             [0],
             [false],
@@ -137,9 +145,9 @@ class FormTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider onePartModelValueProvider
+     * @dataProvider onePartScalarViewValueProvider
      */
-    public function testOnePartFieldPreservesFalsyViewValues($modelValue)
+    public function testOnePartFieldPreservesScalarViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);
 

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -14,6 +14,8 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 require_once CORE_PATH.'kumbia/kumbia_view.php';
 
 if (!class_exists('View', false)) {
@@ -74,9 +76,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         return $data;
     }
 
-    /**
-     * @dataProvider checkedFieldProvider
-     */
+    #[DataProvider('checkedFieldProvider')]
     public function testCheckedFieldsUsePostThenModelThenFallback(
         $helper,
         $modelValue,
@@ -112,9 +112,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider twoPartViewValueProvider
-     */
+    #[DataProvider('twoPartViewValueProvider')]
     public function testTwoPartFieldUsesViewValueOrFallback($hasViewValue, $viewValue, $expected)
     {
         $this->viewData->setValue(null, $hasViewValue ? ['record' => $viewValue] : []);
@@ -144,9 +142,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider onePartScalarViewValueProvider
-     */
+    #[DataProvider('onePartScalarViewValueProvider')]
     public function testOnePartFieldPreservesScalarViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);
@@ -156,9 +152,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($modelValue, $actual);
     }
 
-    /**
-     * @dataProvider onePartNonScalarValueProvider
-     */
+    #[DataProvider('onePartScalarViewValueProvider')]
     public function testOnePartFieldIgnoresObjectAndArrayViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -127,6 +127,59 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('0', $actual);
     }
 
+    public function onePartModelValueProvider()
+    {
+        return [
+            ['0'],
+            [0],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider onePartModelValueProvider
+     */
+    public function testOnePartFieldPreservesFalsyViewValues($modelValue)
+    {
+        $this->viewData->setValue(null, ['status' => $modelValue]);
+
+        [, , $actual] = Form::getFieldData('status', 'fallback', false);
+
+        $this->assertSame($modelValue, $actual);
+    }
+
+    /**
+     * @dataProvider onePartNonScalarValueProvider
+     */
+    public function testOnePartFieldIgnoresObjectAndArrayViewValues($modelValue)
+    {
+        $this->viewData->setValue(null, ['status' => $modelValue]);
+
+        [, , $actual] = Form::getFieldData('status', 'fallback', false);
+
+        $this->assertSame('fallback', $actual);
+    }
+
+    public function onePartNonScalarValueProvider()
+    {
+        return [
+            [(object) ['value' => 'ignored']],
+            [['value' => 'ignored']],
+        ];
+    }
+
+    public function testOnePartFieldUsesFallbackForNullOrUnavailableViewValue()
+    {
+        $this->viewData->setValue(null, ['status' => null]);
+        [, , $nullValue] = Form::getFieldData('status', 'fallback', false);
+
+        $this->viewData->setValue(null, []);
+        [, , $unavailableValue] = Form::getFieldData('status', 'fallback', false);
+
+        $this->assertSame('fallback', $nullValue);
+        $this->assertSame('fallback', $unavailableValue);
+    }
+
     public function testOnePartCheckedFieldUsesFallbackWithoutModelProperty()
     {
         $this->viewData->setValue(null, ['record' => (object) ['flag' => 1]]);

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -50,7 +50,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->viewData->setValue(null, $this->originalViewData);
     }
 
-    public static function checkedFieldProvider()
+    public static function checkedFieldProvider(): array
     {
         $cases = [
             [1, false, null, 1, false, true],
@@ -96,7 +96,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, str_contains($html, 'checked="checked"'));
     }
 
-    public static function twoPartViewValueProvider()
+    public static function twoPartViewValueProvider(): array
     {
         return [
             'object property' => [true, (object) ['flag' => 'object value'], 'object value'],
@@ -134,7 +134,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('0', $actual);
     }
 
-    public static function onePartScalarViewValueProvider()
+    public static function onePartScalarViewValueProvider(): array
     {
         return [
             ['active'],
@@ -168,7 +168,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('fallback', $actual);
     }
 
-    public static function onePartNonScalarValueProvider()
+    public static function onePartNonScalarValueProvider(): array
     {
         return [
             [(object) ['value' => 'ignored']],

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -37,7 +37,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         m::close();
     }
 
-    public function imgDataProvider()
+    public static function imgDataProvider()
     {
         return array(
             array(

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -37,7 +37,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         m::close();
     }
 
-    public static function imgDataProvider()
+    public static function imgDataProvider(): array
     {
         return array(
             array(
@@ -121,7 +121,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, Html::link('action-name', 'Action name', array('a' => 'b', 'c' => 'd')));
     }
 
-    public static function linkActionDataProvider()
+    public static function linkActionDataProvider(): array
     {
         return array(
             array('action', 'controller', sprintf('href="%scontroller/action"', PUBLIC_PATH)),

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -61,9 +61,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider imgDataProvider
-     */
+    #[DataProvider('imgDataProvider')]
     public function testImg($img, $alt, $attrs, $expected)
     {
         //$tagMock = m::mock('alias:Tag');
@@ -131,9 +129,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider linkActionDataProvider
-     */
+    #[DataProvider('linkActionDataProvider')]
     public function testLinkActionHrefPattern($action, $controllerPath, $expected)
     {
         $routerMock = m::mock('alias:Router');

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -121,7 +121,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, Html::link('action-name', 'Action name', array('a' => 'b', 'c' => 'd')));
     }
 
-    public function linkActionDataProvider()
+    public static function linkActionDataProvider()
     {
         return array(
             array('action', 'controller', sprintf('href="%scontroller/action"', PUBLIC_PATH)),

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -14,6 +14,7 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use \Mockery as m;
 
 /**
@@ -24,8 +25,6 @@ use \Mockery as m;
  */
 class HtmlTest extends PHPUnit\Framework\TestCase
 {
-    //use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     protected function tearDown(): void
     {
         /*

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -21,6 +21,8 @@
  */
 class TagTest extends PHPUnit\Framework\TestCase
 {
+    use PHPUnit\Framework\Attributes\DataProvider;
+
     public static function jsFileProvider(): array
     {
         return array(

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -21,7 +21,7 @@
  */
 class TagTest extends PHPUnit\Framework\TestCase
 {
-    public function jsFileProvider()
+    public static function jsFileProvider()
     {
         return array(
             array('file'),
@@ -91,7 +91,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         $this->assertInternalCssValue('css3', 'screen', $files[2]);
     }
 
-    public function createTagDataProvider()
+    public static function createTagDataProvider()
     {
         return array(
             array(

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -21,7 +21,7 @@
  */
 class TagTest extends PHPUnit\Framework\TestCase
 {
-    public static function jsFileProvider()
+    public static function jsFileProvider(): array
     {
         return array(
             array('file'),
@@ -91,7 +91,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         $this->assertInternalCssValue('css3', 'screen', $files[2]);
     }
 
-    public static function createTagDataProvider()
+    public static function createTagDataProvider(): array
     {
         return array(
             array(

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -30,9 +30,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider jsFileProvider
-     */
+    #[DataProvider('jsFileProvider')]
     public function testJs($file)
     {
         $scriptPattern = '<script type="text/javascript" src="%sjavascript/%s"></script>';
@@ -42,9 +40,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $response);
     }
 
-    /**
-     * @dataProvider jsFileProvider
-     */
+    #[DataProvider('jsFileProvider')]
     public function testJsNoCache($file)
     {
         $scriptPattern = '<script type="text/javascript" src="%sjavascript/%s?nocache=';
@@ -121,9 +117,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider createTagDataProvider
-     */
+    #[DataProvider('createTagDataProvider')]
     public function testCreateWithoutContent($tag, $attrs, $content, $expectedResult)
     {
         ob_start();

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -14,6 +14,8 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * 
  * @category   Test
@@ -21,8 +23,6 @@
  */
 class TagTest extends PHPUnit\Framework\TestCase
 {
-    use PHPUnit\Framework\Attributes\DataProvider;
-
     public static function jsFileProvider(): array
     {
         return array(

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -77,9 +77,7 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         $this->assertSuccessfulPath($result, $app);
     }
 
-    /**
-     * @dataProvider configFileProvider
-     */
+    #[DataProvider('configFileProvider')]
     public function testConfigFileIdentifiesAnApp(string $configFile): void
     {
         $app = $this->temporaryDirectory . '/config-app';
@@ -114,9 +112,7 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         $this->assertSame('configured', $result['stdout']);
     }
 
-    /**
-     * @dataProvider trailingSeparatorProvider
-     */
+    #[DataProvider('trailingSeparatorProvider')]
     public function testAcceptedPathHasOnePlatformSeparator(string $separator): void
     {
         $app = $this->temporaryDirectory . '/trailing-app';

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -90,7 +90,7 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         $this->assertSuccessfulPath($result, $app);
     }
 
-    public function configFileProvider(): array
+    public static function configFileProvider(): array
     {
         return [
             ['config.php'],
@@ -127,7 +127,7 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         $this->assertSuccessfulPath($result, $app);
     }
 
-    public function trailingSeparatorProvider(): array
+    public static function trailingSeparatorProvider(): array
     {
         return [
             ['/'],

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -14,10 +14,10 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class ConsoleTest extends PHPUnit\Framework\TestCase
 {
-    use PHPUnit\Framework\Attributes\DataProvider;
-
     private $consoleEntrypoint;
     private $temporaryDirectory;
 

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -16,6 +16,8 @@
 
 class ConsoleTest extends PHPUnit\Framework\TestCase
 {
+    use PHPUnit\Framework\Attributes\DataProvider;
+
     private $consoleEntrypoint;
     private $temporaryDirectory;
 

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -14,6 +14,8 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * @category    Test
  * @package     Core
@@ -22,8 +24,6 @@
  */
 class UtilTest extends PHPUnit\Framework\TestCase
 {
-    use PHPUnit\Framework\Attributes\DataProvider;
-
     public static function underescoreDataProvider(): array
     {
         return array(

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -22,7 +22,7 @@
  */
 class UtilTest extends PHPUnit\Framework\TestCase
 {
-    public function underescoreDataProvider()
+    public static function underescoreDataProvider()
     {
         return array(
             array('Hello World', 'Hello_World'),
@@ -38,7 +38,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function dashDataProvider()
+    public static function dashDataProvider()
     {
         return array(
             array('Hello World', 'Hello-World'),
@@ -55,7 +55,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function humanizeDataProvider()
+    public static function humanizeDataProvider()
     {
         return array(
             array('Hello-World', 'Hello World'),
@@ -74,7 +74,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function encomillarDataProvider()
+    public static function encomillarDataProvider()
     {
         return array(
             array('a,b,c', '"a","b","c"'),
@@ -84,7 +84,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function camelcaseDataProvider()
+    public static function camelcaseDataProvider()
     {
         return array(
             array('a_b_c', 'ABC', 'aBC'),
@@ -105,7 +105,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function smallcaseDataProvider()
+    public static function smallcaseDataProvider()
     {
         return array(
             array('ABC', 'a_b_c'),
@@ -118,7 +118,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function getParamsDataProvider()
+    public static function getParamsDataProvider()
     {
         return array(
             array(array(), array()),

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -22,6 +22,8 @@
  */
 class UtilTest extends PHPUnit\Framework\TestCase
 {
+    use PHPUnit\Framework\Attributes\DataProvider;
+
     public static function underescoreDataProvider(): array
     {
         return array(

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -22,7 +22,7 @@
  */
 class UtilTest extends PHPUnit\Framework\TestCase
 {
-    public static function underescoreDataProvider()
+    public static function underescoreDataProvider(): array
     {
         return array(
             array('Hello World', 'Hello_World'),
@@ -38,7 +38,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function dashDataProvider()
+    public static function dashDataProvider(): array
     {
         return array(
             array('Hello World', 'Hello-World'),
@@ -55,7 +55,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function humanizeDataProvider()
+    public static function humanizeDataProvider(): array
     {
         return array(
             array('Hello-World', 'Hello World'),
@@ -74,7 +74,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function encomillarDataProvider()
+    public static function encomillarDataProvider(): array
     {
         return array(
             array('a,b,c', '"a","b","c"'),
@@ -84,7 +84,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function camelcaseDataProvider()
+    public static function camelcaseDataProvider(): array
     {
         return array(
             array('a_b_c', 'ABC', 'aBC'),
@@ -105,7 +105,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function smallcaseDataProvider()
+    public static function smallcaseDataProvider(): array
     {
         return array(
             array('ABC', 'a_b_c'),
@@ -118,7 +118,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function getParamsDataProvider()
+    public static function getParamsDataProvider(): array
     {
         return array(
             array(array(), array()),

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -139,9 +139,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider underescoreDataProvider
-     */
+    #[DataProvider('underescoreDataProvider')]
     public function testUnderescore($original, $expected)
     {
         $result = Util::underscore($original);
@@ -149,9 +147,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider dashDataProvider
-     */
+    #[DataProvider('dashDataProvider')]
     public function testDash($original, $expected)
     {
         $result = Util::dash($original);
@@ -159,9 +155,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider humanizeDataProvider
-     */
+    #[DataProvider('humanizeDataProvider')]
     public function testHumanize($original, $expected)
     {
         $result = Util::humanize($original);
@@ -169,9 +163,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider encomillarDataProvider
-     */
+    #[DataProvider('encomillarDataProvider')]
     public function testEncomillar($original, $expected)
     {
         $result = Util::encomillar($original);
@@ -179,9 +171,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider camelcaseDataProvider
-     */
+    #[DataProvider('camelcaseDataProvider')]
     public function testCamelcase($original, $expected, $expectedLowerCase)
     {
         $result = Util::camelcase($original);
@@ -191,9 +181,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expectedLowerCase, $resultLowerCase);
     }
 
-    /**
-     * @dataProvider smallcaseDataProvider
-     */
+    #[DataProvider('smallcaseDataProvider')]
     public function testSmallcase($original, $expected)
     {
         $result = Util::smallcase($original);
@@ -201,9 +189,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider getParamsDataProvider
-     */
+    #[DataProvider('getParamsDataProvider')]
     public function testGetParams($original, $expected)
     {
         $result = Util::getParams($original);

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * KumbiaPHP web & app Framework
+ *
+ * @category   Test
+ * @package    Db
+ * @subpackage Adapters
+ */
+
+require_once CORE_PATH.'libs/db/db_base.php';
+require_once CORE_PATH.'libs/db/db_base_interface.php';
+require_once CORE_PATH.'libs/db/adapters/pdo/interface.php';
+require_once CORE_PATH.'libs/db/adapters/pdo.php';
+
+if (!defined('PGSQL_CONNECT_FORCE_NEW')) {
+    define('PGSQL_CONNECT_FORCE_NEW', 2);
+}
+
+require_once CORE_PATH.'libs/db/adapters/pgsql.php';
+require_once CORE_PATH.'libs/db/adapters/pdo/pgsql.php';
+
+class PgsqlDescribeTableNativeDouble extends DbPgSQL
+{
+    public $queries = [];
+    public $rows = null;
+
+    public function __construct()
+    {
+    }
+
+    public function fetch_all($sql)
+    {
+        $this->queries[] = $sql;
+
+        return $this->rows === null ? PgsqlDescribeTableTest::metadataRows() : $this->rows;
+    }
+}
+
+class PgsqlDescribeTablePdoDouble extends DbPdoPgSQL
+{
+    public $queries = [];
+    public $rows = null;
+
+    public function __construct()
+    {
+    }
+
+    public function fetch_all($sql)
+    {
+        $this->queries[] = $sql;
+
+        return $this->rows === null ? PgsqlDescribeTableTest::metadataRows() : $this->rows;
+    }
+}
+
+class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
+{
+    public static function metadataRows()
+    {
+        return [
+            [
+                'field' => 'id',
+                'type' => 'int4',
+                'null' => 'NO',
+                'key' => 'PRI',
+                'default' => 'nextval(\'orders_id_seq\'::regclass)',
+            ],
+        ];
+    }
+
+    public function testBothAdaptersSelectOnlyTheExplicitSchema()
+    {
+        foreach ($this->adapters() as $adapter) {
+            $adapter->describe_table('orders', 'reporting');
+            $sql = $adapter->queries[0];
+
+            $this->assertStringContainsString('pg_catalog.pg_namespace n', $sql);
+            $this->assertStringContainsString('n.oid = c.relnamespace', $sql);
+            $this->assertStringContainsString("n.nspname = 'reporting'", $sql);
+        }
+    }
+
+    public function testBothAdaptersDefaultOmittedSchemaToPublic()
+    {
+        foreach ($this->adapters() as $adapter) {
+            $adapter->describe_table('orders');
+
+            $this->assertStringContainsString("n.nspname = 'public'", $adapter->queries[0]);
+        }
+    }
+
+    /**
+     * @dataProvider emptySchemaInputs
+     */
+    public function testBothAdaptersDefaultNullAndEmptySchemaToPublic($schema)
+    {
+        foreach ($this->adapters() as $adapter) {
+            $adapter->describe_table('orders', $schema);
+
+            $this->assertStringContainsString("n.nspname = 'public'", $adapter->queries[0]);
+        }
+    }
+
+    public function emptySchemaInputs()
+    {
+        return [
+            'null schema' => [null],
+            'empty schema' => [''],
+        ];
+    }
+
+    public function testNamespacePredicatePreventsFallbackToAnotherSchemasTable()
+    {
+        foreach ($this->adapters() as $adapter) {
+            $adapter->describe_table('orders', 'missing_schema');
+            $sql = $adapter->queries[0];
+
+            $this->assertStringContainsString("c.relname = 'orders'", $sql);
+            $this->assertStringContainsString("n.nspname = 'missing_schema'", $sql);
+            $this->assertStringNotContainsString('OR n.nspname', $sql);
+        }
+    }
+
+    public function testBothAdaptersEscapeQuotesInTheSchemaPredicate()
+    {
+        foreach ($this->adapters() as $adapter) {
+            $adapter->describe_table('orders', "reporting' OR true --");
+            $sql = $adapter->queries[0];
+
+            $this->assertStringContainsString("n.nspname = 'reporting'' OR true --'", $sql);
+            $this->assertStringNotContainsString("n.nspname = 'reporting' OR true --", $sql);
+        }
+    }
+
+    public function testBothAdaptersReturnAnEmptyArrayWhenTheRequestedSchemaHasNoTable()
+    {
+        foreach ($this->adapters() as $adapter) {
+            $adapter->rows = [];
+
+            $this->assertSame([], $adapter->describe_table('orders', 'missing_schema'));
+        }
+    }
+
+    public function testBothAdaptersPreserveTheExistingMetadataShape()
+    {
+        foreach ($this->adapters() as $adapter) {
+            $this->assertSame([
+                [
+                    'Field' => 'id',
+                    'Type' => 'int4',
+                    'Null' => 'NO',
+                    'Key' => 'PRI',
+                    'Default' => 'nextval(\'orders_id_seq\'::regclass)',
+                ],
+            ], $adapter->describe_table('orders', 'reporting'));
+        }
+    }
+
+    private function adapters()
+    {
+        return [
+            new PgsqlDescribeTableNativeDouble(),
+            new PgsqlDescribeTablePdoDouble(),
+        ];
+    }
+}

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -121,17 +121,6 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    public function testBothAdaptersEscapeQuotesInTheSchemaPredicate()
-    {
-        foreach ($this->adapters() as $adapter) {
-            $adapter->describe_table('orders', "reporting' OR true --");
-            $sql = $adapter->queries[0];
-
-            $this->assertStringContainsString("n.nspname = 'reporting'' OR true --'", $sql);
-            $this->assertStringNotContainsString("n.nspname = 'reporting' OR true --", $sql);
-        }
-    }
-
     public function testBothAdaptersReturnAnEmptyArrayWhenTheRequestedSchemaHasNoTable()
     {
         foreach ($this->adapters() as $adapter) {

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -15,6 +15,11 @@ require_once CORE_PATH.'libs/db/adapters/pdo.php';
 if (!defined('PGSQL_CONNECT_FORCE_NEW')) {
     define('PGSQL_CONNECT_FORCE_NEW', 2);
 }
+if (!defined('PGSQL_ASSOC')) {
+    define('PGSQL_ASSOC', 1);
+    define('PGSQL_NUM', 2);
+    define('PGSQL_BOTH', 3);
+}
 
 require_once CORE_PATH.'libs/db/adapters/pgsql.php';
 require_once CORE_PATH.'libs/db/adapters/pdo/pgsql.php';

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -97,7 +97,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider emptySchemaInputs
+     * @dataProvider emptySchemaInputsProvider
      */
     public function testBothAdaptersDefaultNullAndEmptySchemaToPublic($schema)
     {
@@ -108,7 +108,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    public static function emptySchemaInputs(): array
+    public static function emptySchemaInputsProvider(): array
     {
         return [
             'null schema' => [null],

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -26,6 +26,7 @@ class PgsqlDescribeTableNativeDouble extends DbPgSQL
 
     public function __construct()
     {
+        // Intentionally bypass the parent constructor to avoid opening a database connection.
     }
 
     public function fetch_all($sql)
@@ -43,6 +44,7 @@ class PgsqlDescribeTablePdoDouble extends DbPdoPgSQL
 
     public function __construct()
     {
+        // Intentionally bypass the parent constructor to avoid opening a database connection.
     }
 
     public function fetch_all($sql)

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -108,7 +108,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    public function emptySchemaInputs()
+    public static function emptySchemaInputs()
     {
         return [
             'null schema' => [null],

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -96,9 +96,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @dataProvider emptySchemaInputsProvider
-     */
+    #[DataProvider('emptySchemaInputsProvider')]
     public function testBothAdaptersDefaultNullAndEmptySchemaToPublic($schema)
     {
         foreach ($this->adapters() as $adapter) {

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -108,7 +108,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    public static function emptySchemaInputs()
+    public static function emptySchemaInputs(): array
     {
         return [
             'null schema' => [null],

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -7,6 +7,8 @@
  * @subpackage Adapters
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 require_once CORE_PATH.'libs/db/db_base.php';
 require_once CORE_PATH.'libs/db/db_base_interface.php';
 require_once CORE_PATH.'libs/db/adapters/pdo/interface.php';

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -191,4 +191,24 @@ class InputTest extends PHPUnit\Framework\TestCase
         $this->assertSame('', Input::post('index1.index5'));
         $this->assertSame('', Input::post('index61'));
     }
+
+    public function testHasPostRecognizesPresentFalsyValuesAndNestedKeys()
+    {
+        $values = [
+            'empty_string' => '',
+            'false' => false,
+            'null' => null,
+            'empty_array' => [],
+            'integer_zero' => 0,
+            'string_zero' => '0',
+        ];
+        $_POST = $values + ['record' => $values];
+
+        foreach (array_keys($values) as $key) {
+            $this->assertTrue(Input::hasPost($key));
+            $this->assertTrue(Input::hasPost("record.$key"));
+        }
+        $this->assertFalse(Input::hasPost('record.missing'));
+        $this->assertFalse(Input::hasPost('record.false.missing'));
+    }
 }

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -60,9 +60,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider isMethodProvider
-     */
+    #[DataProvider('isMethodProvider')]
     public function testIsMethod($expectedMethod, $method, $canBeTrue)
     {
         $_SERVER['REQUEST_METHOD'] = $method;
@@ -143,9 +141,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider getRequestTestingDataProvider
-     */
+    #[DataProvider('getRequestTestingDataProvider')]
     public function testRequestSimpleIndex(&$GLOBAl, $method)
     {
         $hasMethod = 'has'.ucfirst($method);
@@ -157,9 +153,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         $this->assertSame('value', Input::$method('__post_index__'));
     }
 
-    /**
-     * @dataProvider getRequestTestingDataProvider
-     */
+    #[DataProvider('getRequestTestingDataProvider')]
     public function testRequestWithoutIndex(&$GLOBAl, $method)
     {
         $this->assertEmpty(Input::$method());
@@ -169,9 +163,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         $this->assertSame(['__post_index__' => 'value'], Input::$method());
     }
 
-    /**
-     * @dataProvider getRequestTestingDataProvider
-     */
+     #[DataProvider('getRequestTestingDataProvider')]
     public function testRequestNestedIndex(&$GLOBAL, $method)
     {
         $this->assertSame('', Input::post('index1.index2.index4'));

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -44,7 +44,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         [$_GET, $_POST, $_REQUEST, $_SERVER] = $this->originalValues;
     }
 
-    public static function isMethodProvider()
+    public static function isMethodProvider(): array
     {
         return [
             ['GET', 'GET', true],

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -134,7 +134,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         $this->assertSame('__test_ip__', Input::ip());
     }
 
-    public function getRequestTestingData()
+    public static function getRequestTestingDataProvider(): array
     {
         return [
             [&$_POST, 'post'],
@@ -144,7 +144,7 @@ class InputTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider getRequestTestingData
+     * @dataProvider getRequestTestingDataProvider
      */
     public function testRequestSimpleIndex(&$GLOBAl, $method)
     {
@@ -158,7 +158,7 @@ class InputTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider getRequestTestingData
+     * @dataProvider getRequestTestingDataProvider
      */
     public function testRequestWithoutIndex(&$GLOBAl, $method)
     {
@@ -170,7 +170,7 @@ class InputTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider getRequestTestingData
+     * @dataProvider getRequestTestingDataProvider
      */
     public function testRequestNestedIndex(&$GLOBAL, $method)
     {

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -18,6 +18,8 @@
  * @license    http://wiki.kumbiaphp.com/Licencia     New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * @category Test
  */

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -44,7 +44,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         [$_GET, $_POST, $_REQUEST, $_SERVER] = $this->originalValues;
     }
 
-    public function isMethodProvider()
+    public static function isMethodProvider()
     {
         return [
             ['GET', 'GET', true],

--- a/core/tests/integration/libs/db/adapters/PgsqlDescribeTableIntegrationTest.php
+++ b/core/tests/integration/libs/db/adapters/PgsqlDescribeTableIntegrationTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * KumbiaPHP web & app Framework
+ *
+ * @category   Test
+ * @package    Db
+ * @subpackage Adapters
+ */
+
+class PgsqlDescribeTableIntegrationTest extends PHPUnit\Framework\TestCase
+{
+    private $native;
+    private $pdo;
+    private $schema;
+    private $table;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pgsql')) {
+            $this->markTestSkipped('PostgreSQL integration requires the pgsql extension.');
+        }
+        if (!extension_loaded('pdo_pgsql')) {
+            $this->markTestSkipped('PostgreSQL integration requires the pdo_pgsql extension.');
+        }
+
+        $config = $this->configuration();
+
+        require_once CORE_PATH.'libs/db/db_base.php';
+        require_once CORE_PATH.'libs/db/db_base_interface.php';
+        require_once CORE_PATH.'libs/db/adapters/pdo/interface.php';
+        require_once CORE_PATH.'libs/db/adapters/pdo.php';
+        require_once CORE_PATH.'libs/db/adapters/pgsql.php';
+        require_once CORE_PATH.'libs/db/adapters/pdo/pgsql.php';
+
+        try {
+            $this->native = new DbPgSQL($config);
+            $this->pdo = new DbPdoPgSQL([
+                'type' => 'pgsql',
+                'dsn' => "host={$config['host']};port={$config['port']};dbname={$config['name']}",
+                'username' => $config['username'],
+                'password' => $config['password'],
+            ]);
+        } catch (Throwable $exception) {
+            $this->markTestSkipped('PostgreSQL integration runtime is unavailable: '.$exception->getMessage());
+        }
+
+        $suffix = strtolower(dechex(getmypid()).dechex(random_int(0, PHP_INT_MAX)));
+        $this->schema = 'kumbia_issue118_'.$suffix;
+        $this->table = 'schema_metadata_'.$suffix;
+
+        try {
+            $this->native->query("CREATE SCHEMA {$this->schema}");
+            $this->native->query("CREATE TABLE public.{$this->table} (public_id integer PRIMARY KEY, public_only text)");
+            $this->native->query("CREATE TABLE {$this->schema}.{$this->table} (custom_id integer PRIMARY KEY, custom_only text)");
+        } catch (Throwable $exception) {
+            $this->cleanup();
+            $this->markTestSkipped('PostgreSQL integration fixtures cannot be created: '.$exception->getMessage());
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanup();
+    }
+
+    public function testBothAdaptersIsolatePublicAndCustomSchemaMetadata()
+    {
+        foreach ([$this->native, $this->pdo] as $adapter) {
+            $this->assertSame(['custom_id', 'custom_only'], $this->fields($adapter->describe_table($this->table, $this->schema)));
+            $this->assertSame(['public_id', 'public_only'], $this->fields($adapter->describe_table($this->table)));
+            $this->assertSame(['public_id', 'public_only'], $this->fields($adapter->describe_table($this->table, null)));
+            $this->assertSame(['public_id', 'public_only'], $this->fields($adapter->describe_table($this->table, '')));
+            $this->assertSame([], $adapter->describe_table($this->table, 'kumbia_issue118_missing'));
+        }
+    }
+
+    private function configuration()
+    {
+        $required = ['PGHOST', 'PGDATABASE', 'PGUSER'];
+        $missing = [];
+        foreach ($required as $name) {
+            if (getenv($name) === false || getenv($name) === '') {
+                $missing[] = $name;
+            }
+        }
+        if ($missing) {
+            $this->markTestSkipped('PostgreSQL integration credentials are unavailable: '.implode(', ', $missing).'.');
+        }
+
+        return [
+            'host' => getenv('PGHOST'),
+            'port' => getenv('PGPORT') ?: 5432,
+            'name' => getenv('PGDATABASE'),
+            'username' => getenv('PGUSER'),
+            'password' => getenv('PGPASSWORD') ?: '',
+        ];
+    }
+
+    private function fields($metadata)
+    {
+        return array_column($metadata, 'Field');
+    }
+
+    private function cleanup()
+    {
+        if (!$this->native || !$this->schema || !$this->table) {
+            return;
+        }
+
+        try {
+            $this->native->query("DROP TABLE IF EXISTS public.{$this->table}");
+            $this->native->query("DROP SCHEMA IF EXISTS {$this->schema} CASCADE");
+        } catch (Throwable $exception) {
+        }
+    }
+}

--- a/core/tests/integration/libs/db/adapters/PgsqlDescribeTableIntegrationTest.php
+++ b/core/tests/integration/libs/db/adapters/PgsqlDescribeTableIntegrationTest.php
@@ -111,6 +111,7 @@ class PgsqlDescribeTableIntegrationTest extends PHPUnit\Framework\TestCase
             $this->native->query("DROP TABLE IF EXISTS public.{$this->table}");
             $this->native->query("DROP SCHEMA IF EXISTS {$this->schema} CASCADE");
         } catch (Throwable $exception) {
+            // Cleanup failures must not mask the primary test result.
         }
     }
 }

--- a/default/app/phpunit.xml.dist
+++ b/default/app/phpunit.xml.dist
@@ -7,7 +7,6 @@
     bootstrap="./tests/bootstrap.php">
     <php>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
     </php>
 
     <!-- Add any additional test suites you want to run here -->


### PR DESCRIPTION
## Summary

Integrate the current `dev` branch into `master`, including framework fixes, PostgreSQL adapter improvements, PHPUnit compatibility updates, and CI modernization.

## Changes

### Framework and database

- Improve form helper model-value handling, including checked fields and scalar values for simple fields.
- Consolidate form model lookup and simple-field scalar rules.
- Improve PostgreSQL table description handling by escaping identifiers correctly and filtering metadata by schema.
- Resolve PostgreSQL subquery limits and related test dependencies.
- Update input and helper behavior covered by the expanded test suite.

### PHPUnit and supported PHP versions

- Update PHPUnit version constraints.
- Raise the minimum PHP requirement to 8.1 and remove PHP 8.0 from the test matrix.
- Add PHP 8.6 to the CI matrix.
- Convert PHPUnit data providers from PHPDoc annotations to attributes.
- Make data providers static and add the required return type declarations.
- Standardize provider names and clean up obsolete provider-related imports and settings.

### CI and test configuration

- Update GitHub Actions dependencies, including `actions/checkout`.
- Enable the required opcache extension in the PHPUnit workflow.
- Remove obsolete APC and opcache CLI settings from PHPUnit configuration.
- Add and expand unit and integration coverage for form helpers and PostgreSQL metadata handling.

## Validation

- PHPUnit workflow passes on PHP 8.1, 8.2, 8.3, 8.4, 8.5 and 8.6.
- Scrutinizer reports no new issues and tests pass.
- SonarCloud analysis passes.
- Guardrails security scan passes.

This PR is an integration of the upstream `dev` branch into `master`.