### PR TITLE
chore: add bilingual issue report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_en.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_en.yaml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Report a reproducible problem in KumbiaPHP.
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: Describe the problem clearly.
+      placeholder: What went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: List the minimum steps needed to reproduce the problem.
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      description: Describe what happened instead.
+      placeholder: What happened instead?
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: KumbiaPHP/PHP version
+      description: Provide the KumbiaPHP and PHP versions in use.
+      placeholder: "KumbiaPHP 1.x.x; PHP 8.x"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_es.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_es.yaml
@@ -1,0 +1,45 @@
+name: Reporte de error
+description: Reporta un problema reproducible en KumbiaPHP.
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Descripción del problema
+      description: Describe claramente el problema.
+      placeholder: ¿Qué ocurrió?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Pasos para reproducirlo
+      description: Enumera los pasos mínimos para reproducir el problema.
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Comportamiento esperado
+      description: Describe lo que esperabas que ocurriera.
+      placeholder: ¿Qué debería haber ocurrido?
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Comportamiento actual
+      description: Describe lo que ocurrió en su lugar.
+      placeholder: ¿Qué ocurrió en su lugar?
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Versiones de KumbiaPHP y PHP
+      description: Indica las versiones de KumbiaPHP y PHP utilizadas.
+      placeholder: "KumbiaPHP 1.x.x; PHP 8.x"
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

- Add a basic English GitHub issue form for bug reports.
- Add an equivalent Spanish GitHub issue form.

## Validation

- [x] YAML parsing and structure checks completed.
- [x] Whitespace check completed with `git diff --check`.

## Bootstrap note

This PR bootstraps issue reporting for the repository. It does not link an existing issue because the upstream repository did not yet provide an issue form or a matching issue. It also does not add a `type:*` label because none currently exists upstream.