### PR TITLE
Fix integer check from is_integer() to is_int()

### DIFF
--- a/core/libs/validate/validate.php
+++ b/core/libs/validate/validate.php
@@ -138,7 +138,7 @@ class Validate
      */
     protected static function getRuleName($ruleName, $param){
          /*Evita tener que colocar un null cuando no se pasan parametros*/
-        return is_integer($ruleName) && is_string($param)?$param:$ruleName;
+        return is_int($ruleName) && is_string($param)?$param:$ruleName;
     }
 
     /**


### PR DESCRIPTION
`is_integer()` is deprecated in PHP 8.6