### PR TITLE
Testing phpunit new versions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -51,6 +51,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: composer
           extensions: gd, sqlite3, opcache
+          ini-values: opcache.enable_cli=1
           coverage: none
         env:
           update: true

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
         phpunit-versions: ['latest']
 
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer
-          extensions: gd, sqlite3
+          extensions: gd, sqlite3, opcache
           coverage: none
         env:
           update: true

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "license": "BSD-3-Clause",
     "name": "kumbia/framework",
     "require": {
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9 || ^10 || ^11 || ^12 || ^13",
+        "phpunit/phpunit": "^10 || ^11 || ^12 || ^13",
         "mockery/mockery": "^1"
     },
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -22,3 +22,4 @@
     },
     "type": "project"
 }
+

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": ">=8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9 || ^10 || ^11 || ^12 || ^13",
         "mockery/mockery": "^1"
     },
     "support": {

--- a/core/libs/validate/validate.php
+++ b/core/libs/validate/validate.php
@@ -138,7 +138,7 @@ class Validate
      */
     protected static function getRuleName($ruleName, $param){
          /*Evita tener que colocar un null cuando no se pasan parametros*/
-        return is_integer($ruleName) && is_string($param)?$param:$ruleName;
+        return is_int($ruleName) && is_string($param)?$param:$ruleName;
     }
 
     /**

--- a/core/phpunit.xml.dist
+++ b/core/phpunit.xml.dist
@@ -10,8 +10,6 @@
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
-        <ini name="opcache.enable_cli" value="1"/>
     </php>
 
     <testsuites>

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -152,7 +152,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($modelValue, $actual);
     }
 
-    #[DataProvider('onePartNonScalarViewValueProvider')]
+    #[DataProvider('onePartNonScalarValueProvider')]
     public function testOnePartFieldIgnoresObjectAndArrayViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -152,7 +152,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($modelValue, $actual);
     }
 
-    #[DataProvider('onePartScalarViewValueProvider')]
+    #[DataProvider('onePartNonScalarViewValueProvider')]
     public function testOnePartFieldIgnoresObjectAndArrayViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -14,6 +14,8 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 require_once CORE_PATH.'kumbia/kumbia_view.php';
 
 if (!class_exists('View', false)) {
@@ -74,9 +76,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         return $data;
     }
 
-    /**
-     * @dataProvider checkedFieldProvider
-     */
+    #[DataProvider('checkedFieldProvider')]
     public function testCheckedFieldsUsePostThenModelThenFallback(
         $helper,
         $modelValue,
@@ -112,9 +112,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider twoPartViewValueProvider
-     */
+    #[DataProvider('twoPartViewValueProvider')]
     public function testTwoPartFieldUsesViewValueOrFallback($hasViewValue, $viewValue, $expected)
     {
         $this->viewData->setValue(null, $hasViewValue ? ['record' => $viewValue] : []);
@@ -144,9 +142,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider onePartScalarViewValueProvider
-     */
+    #[DataProvider('onePartScalarViewValueProvider')]
     public function testOnePartFieldPreservesScalarViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);
@@ -156,9 +152,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($modelValue, $actual);
     }
 
-    /**
-     * @dataProvider onePartNonScalarValueProvider
-     */
+    #[DataProvider('onePartScalarViewValueProvider')]
     public function testOnePartFieldIgnoresObjectAndArrayViewValues($modelValue)
     {
         $this->viewData->setValue(null, ['status' => $modelValue]);

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -37,7 +37,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         m::close();
     }
 
-    public function imgDataProvider()
+    public static function imgDataProvider()
     {
         return array(
             array(

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -37,7 +37,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         m::close();
     }
 
-    public static function imgDataProvider()
+    public static function imgDataProvider(): array
     {
         return array(
             array(
@@ -121,7 +121,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, Html::link('action-name', 'Action name', array('a' => 'b', 'c' => 'd')));
     }
 
-    public static function linkActionDataProvider()
+    public static function linkActionDataProvider(): array
     {
         return array(
             array('action', 'controller', sprintf('href="%scontroller/action"', PUBLIC_PATH)),

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -61,9 +61,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider imgDataProvider
-     */
+    #[DataProvider('imgDataProvider')]
     public function testImg($img, $alt, $attrs, $expected)
     {
         //$tagMock = m::mock('alias:Tag');
@@ -131,9 +129,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider linkActionDataProvider
-     */
+    #[DataProvider('linkActionDataProvider')]
     public function testLinkActionHrefPattern($action, $controllerPath, $expected)
     {
         $routerMock = m::mock('alias:Router');

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -121,7 +121,7 @@ class HtmlTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, Html::link('action-name', 'Action name', array('a' => 'b', 'c' => 'd')));
     }
 
-    public function linkActionDataProvider()
+    public static function linkActionDataProvider()
     {
         return array(
             array('action', 'controller', sprintf('href="%scontroller/action"', PUBLIC_PATH)),

--- a/core/tests/classes/extensions/helpers/HtmlTest.php
+++ b/core/tests/classes/extensions/helpers/HtmlTest.php
@@ -14,6 +14,7 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use \Mockery as m;
 
 /**
@@ -24,8 +25,6 @@ use \Mockery as m;
  */
 class HtmlTest extends PHPUnit\Framework\TestCase
 {
-    //use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
     protected function tearDown(): void
     {
         /*

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -21,6 +21,8 @@
  */
 class TagTest extends PHPUnit\Framework\TestCase
 {
+    use PHPUnit\Framework\Attributes\DataProvider;
+
     public static function jsFileProvider(): array
     {
         return array(

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -21,7 +21,7 @@
  */
 class TagTest extends PHPUnit\Framework\TestCase
 {
-    public function jsFileProvider()
+    public static function jsFileProvider()
     {
         return array(
             array('file'),
@@ -91,7 +91,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         $this->assertInternalCssValue('css3', 'screen', $files[2]);
     }
 
-    public function createTagDataProvider()
+    public static function createTagDataProvider()
     {
         return array(
             array(

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -21,7 +21,7 @@
  */
 class TagTest extends PHPUnit\Framework\TestCase
 {
-    public static function jsFileProvider()
+    public static function jsFileProvider(): array
     {
         return array(
             array('file'),
@@ -91,7 +91,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         $this->assertInternalCssValue('css3', 'screen', $files[2]);
     }
 
-    public static function createTagDataProvider()
+    public static function createTagDataProvider(): array
     {
         return array(
             array(

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -30,9 +30,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider jsFileProvider
-     */
+    #[DataProvider('jsFileProvider')]
     public function testJs($file)
     {
         $scriptPattern = '<script type="text/javascript" src="%sjavascript/%s"></script>';
@@ -42,9 +40,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $response);
     }
 
-    /**
-     * @dataProvider jsFileProvider
-     */
+    #[DataProvider('jsFileProvider')]
     public function testJsNoCache($file)
     {
         $scriptPattern = '<script type="text/javascript" src="%sjavascript/%s?nocache=';
@@ -121,9 +117,7 @@ class TagTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider createTagDataProvider
-     */
+    #[DataProvider('createTagDataProvider')]
     public function testCreateWithoutContent($tag, $attrs, $content, $expectedResult)
     {
         ob_start();

--- a/core/tests/classes/extensions/helpers/TagTest.php
+++ b/core/tests/classes/extensions/helpers/TagTest.php
@@ -14,6 +14,8 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * 
  * @category   Test
@@ -21,8 +23,6 @@
  */
 class TagTest extends PHPUnit\Framework\TestCase
 {
-    use PHPUnit\Framework\Attributes\DataProvider;
-
     public static function jsFileProvider(): array
     {
         return array(

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -77,9 +77,7 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         $this->assertSuccessfulPath($result, $app);
     }
 
-    /**
-     * @dataProvider configFileProvider
-     */
+    #[DataProvider('configFileProvider')]
     public function testConfigFileIdentifiesAnApp(string $configFile): void
     {
         $app = $this->temporaryDirectory . '/config-app';
@@ -114,9 +112,7 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         $this->assertSame('configured', $result['stdout']);
     }
 
-    /**
-     * @dataProvider trailingSeparatorProvider
-     */
+    #[DataProvider('trailingSeparatorProvider')]
     public function testAcceptedPathHasOnePlatformSeparator(string $separator): void
     {
         $app = $this->temporaryDirectory . '/trailing-app';

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -90,7 +90,7 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         $this->assertSuccessfulPath($result, $app);
     }
 
-    public function configFileProvider(): array
+    public static function configFileProvider(): array
     {
         return [
             ['config.php'],
@@ -127,7 +127,7 @@ class ConsoleTest extends PHPUnit\Framework\TestCase
         $this->assertSuccessfulPath($result, $app);
     }
 
-    public function trailingSeparatorProvider(): array
+    public static function trailingSeparatorProvider(): array
     {
         return [
             ['/'],

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -14,10 +14,10 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class ConsoleTest extends PHPUnit\Framework\TestCase
 {
-    use PHPUnit\Framework\Attributes\DataProvider;
-
     private $consoleEntrypoint;
     private $temporaryDirectory;
 

--- a/core/tests/classes/kumbia/ConsoleTest.php
+++ b/core/tests/classes/kumbia/ConsoleTest.php
@@ -16,6 +16,8 @@
 
 class ConsoleTest extends PHPUnit\Framework\TestCase
 {
+    use PHPUnit\Framework\Attributes\DataProvider;
+
     private $consoleEntrypoint;
     private $temporaryDirectory;
 

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -14,6 +14,8 @@
  * @license    https://github.com/KumbiaPHP/KumbiaPHP/blob/master/LICENSE   New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * @category    Test
  * @package     Core
@@ -22,8 +24,6 @@
  */
 class UtilTest extends PHPUnit\Framework\TestCase
 {
-    use PHPUnit\Framework\Attributes\DataProvider;
-
     public static function underescoreDataProvider(): array
     {
         return array(

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -22,7 +22,7 @@
  */
 class UtilTest extends PHPUnit\Framework\TestCase
 {
-    public function underescoreDataProvider()
+    public static function underescoreDataProvider()
     {
         return array(
             array('Hello World', 'Hello_World'),
@@ -38,7 +38,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function dashDataProvider()
+    public static function dashDataProvider()
     {
         return array(
             array('Hello World', 'Hello-World'),
@@ -55,7 +55,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function humanizeDataProvider()
+    public static function humanizeDataProvider()
     {
         return array(
             array('Hello-World', 'Hello World'),
@@ -74,7 +74,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function encomillarDataProvider()
+    public static function encomillarDataProvider()
     {
         return array(
             array('a,b,c', '"a","b","c"'),
@@ -84,7 +84,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function camelcaseDataProvider()
+    public static function camelcaseDataProvider()
     {
         return array(
             array('a_b_c', 'ABC', 'aBC'),
@@ -105,7 +105,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function smallcaseDataProvider()
+    public static function smallcaseDataProvider()
     {
         return array(
             array('ABC', 'a_b_c'),
@@ -118,7 +118,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function getParamsDataProvider()
+    public static function getParamsDataProvider()
     {
         return array(
             array(array(), array()),

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -22,6 +22,8 @@
  */
 class UtilTest extends PHPUnit\Framework\TestCase
 {
+    use PHPUnit\Framework\Attributes\DataProvider;
+
     public static function underescoreDataProvider(): array
     {
         return array(

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -22,7 +22,7 @@
  */
 class UtilTest extends PHPUnit\Framework\TestCase
 {
-    public static function underescoreDataProvider()
+    public static function underescoreDataProvider(): array
     {
         return array(
             array('Hello World', 'Hello_World'),
@@ -38,7 +38,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function dashDataProvider()
+    public static function dashDataProvider(): array
     {
         return array(
             array('Hello World', 'Hello-World'),
@@ -55,7 +55,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function humanizeDataProvider()
+    public static function humanizeDataProvider(): array
     {
         return array(
             array('Hello-World', 'Hello World'),
@@ -74,7 +74,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function encomillarDataProvider()
+    public static function encomillarDataProvider(): array
     {
         return array(
             array('a,b,c', '"a","b","c"'),
@@ -84,7 +84,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function camelcaseDataProvider()
+    public static function camelcaseDataProvider(): array
     {
         return array(
             array('a_b_c', 'ABC', 'aBC'),
@@ -105,7 +105,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function smallcaseDataProvider()
+    public static function smallcaseDataProvider(): array
     {
         return array(
             array('ABC', 'a_b_c'),
@@ -118,7 +118,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public static function getParamsDataProvider()
+    public static function getParamsDataProvider(): array
     {
         return array(
             array(array(), array()),

--- a/core/tests/classes/kumbia/UtilTest.php
+++ b/core/tests/classes/kumbia/UtilTest.php
@@ -139,9 +139,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @dataProvider underescoreDataProvider
-     */
+    #[DataProvider('underescoreDataProvider')]
     public function testUnderescore($original, $expected)
     {
         $result = Util::underscore($original);
@@ -149,9 +147,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider dashDataProvider
-     */
+    #[DataProvider('dashDataProvider')]
     public function testDash($original, $expected)
     {
         $result = Util::dash($original);
@@ -159,9 +155,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider humanizeDataProvider
-     */
+    #[DataProvider('humanizeDataProvider')]
     public function testHumanize($original, $expected)
     {
         $result = Util::humanize($original);
@@ -169,9 +163,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider encomillarDataProvider
-     */
+    #[DataProvider('encomillarDataProvider')]
     public function testEncomillar($original, $expected)
     {
         $result = Util::encomillar($original);
@@ -179,9 +171,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider camelcaseDataProvider
-     */
+    #[DataProvider('camelcaseDataProvider')]
     public function testCamelcase($original, $expected, $expectedLowerCase)
     {
         $result = Util::camelcase($original);
@@ -191,9 +181,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expectedLowerCase, $resultLowerCase);
     }
 
-    /**
-     * @dataProvider smallcaseDataProvider
-     */
+    #[DataProvider('smallcaseDataProvider')]
     public function testSmallcase($original, $expected)
     {
         $result = Util::smallcase($original);
@@ -201,9 +189,7 @@ class UtilTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @dataProvider getParamsDataProvider
-     */
+    #[DataProvider('getParamsDataProvider')]
     public function testGetParams($original, $expected)
     {
         $result = Util::getParams($original);

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -60,9 +60,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider isMethodProvider
-     */
+    #[DataProvider('isMethodProvider')]
     public function testIsMethod($expectedMethod, $method, $canBeTrue)
     {
         $_SERVER['REQUEST_METHOD'] = $method;
@@ -143,9 +141,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @dataProvider getRequestTestingDataProvider
-     */
+    #[DataProvider('getRequestTestingDataProvider')]
     public function testRequestSimpleIndex(&$GLOBAl, $method)
     {
         $hasMethod = 'has'.ucfirst($method);
@@ -157,9 +153,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         $this->assertSame('value', Input::$method('__post_index__'));
     }
 
-    /**
-     * @dataProvider getRequestTestingDataProvider
-     */
+    #[DataProvider('getRequestTestingDataProvider')]
     public function testRequestWithoutIndex(&$GLOBAl, $method)
     {
         $this->assertEmpty(Input::$method());
@@ -169,9 +163,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         $this->assertSame(['__post_index__' => 'value'], Input::$method());
     }
 
-    /**
-     * @dataProvider getRequestTestingDataProvider
-     */
+     #[DataProvider('getRequestTestingDataProvider')]
     public function testRequestNestedIndex(&$GLOBAL, $method)
     {
         $this->assertSame('', Input::post('index1.index2.index4'));

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -44,7 +44,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         [$_GET, $_POST, $_REQUEST, $_SERVER] = $this->originalValues;
     }
 
-    public static function isMethodProvider()
+    public static function isMethodProvider(): array
     {
         return [
             ['GET', 'GET', true],

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -134,7 +134,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         $this->assertSame('__test_ip__', Input::ip());
     }
 
-    public function getRequestTestingData()
+    public static function getRequestTestingDataProvider(): array
     {
         return [
             [&$_POST, 'post'],
@@ -144,7 +144,7 @@ class InputTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider getRequestTestingData
+     * @dataProvider getRequestTestingDataProvider
      */
     public function testRequestSimpleIndex(&$GLOBAl, $method)
     {
@@ -158,7 +158,7 @@ class InputTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider getRequestTestingData
+     * @dataProvider getRequestTestingDataProvider
      */
     public function testRequestWithoutIndex(&$GLOBAl, $method)
     {
@@ -170,7 +170,7 @@ class InputTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider getRequestTestingData
+     * @dataProvider getRequestTestingDataProvider
      */
     public function testRequestNestedIndex(&$GLOBAL, $method)
     {

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -18,6 +18,8 @@
  * @license    http://wiki.kumbiaphp.com/Licencia     New BSD License
  */
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * @category Test
  */

--- a/core/tests/classes/libs/input/InputTest.php
+++ b/core/tests/classes/libs/input/InputTest.php
@@ -44,7 +44,7 @@ class InputTest extends PHPUnit\Framework\TestCase
         [$_GET, $_POST, $_REQUEST, $_SERVER] = $this->originalValues;
     }
 
-    public function isMethodProvider()
+    public static function isMethodProvider()
     {
         return [
             ['GET', 'GET', true],

--- a/default/app/phpunit.xml.dist
+++ b/default/app/phpunit.xml.dist
@@ -7,7 +7,6 @@
     bootstrap="./tests/bootstrap.php">
     <php>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
     </php>
 
     <!-- Add any additional test suites you want to run here -->


### PR DESCRIPTION
We need to fix future problems now.

Added OPCache also, for faster runs.

Theoretically we need to use PHP Unit >=10, and this change need PHP 8.1.
We can't mix `dataProvider` with old and new style.

```php
// Old style (Annotation)
/**
 * @dataProvider provideData
 */
public function testSomething($input) { ... }

public function provideData() { ... }

// New style (Attribute - PHPUnit 10+)
#[DataProvider('provideData')]
public function testSomething($input) { ... }

public static function provideData(): array { ... }   

```