### PR TITLE
fix(tests): make PHPUnit data providers static

### DIFF
--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -50,7 +50,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->viewData->setValue(null, $this->originalViewData);
     }
 
-    public function checkedFieldProvider()
+    public static function checkedFieldProvider()
     {
         $cases = [
             [1, false, null, 1, false, true],
@@ -96,7 +96,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, str_contains($html, 'checked="checked"'));
     }
 
-    public function twoPartViewValueProvider()
+    public static function twoPartViewValueProvider()
     {
         return [
             'object property' => [true, (object) ['flag' => 'object value'], 'object value'],
@@ -134,7 +134,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('0', $actual);
     }
 
-    public function onePartScalarViewValueProvider()
+    public static function onePartScalarViewValueProvider()
     {
         return [
             ['active'],
@@ -168,7 +168,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('fallback', $actual);
     }
 
-    public function onePartNonScalarValueProvider()
+    public static function onePartNonScalarValueProvider()
     {
         return [
             [(object) ['value' => 'ignored']],

--- a/core/tests/classes/extensions/helpers/FormTest.php
+++ b/core/tests/classes/extensions/helpers/FormTest.php
@@ -50,7 +50,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->viewData->setValue(null, $this->originalViewData);
     }
 
-    public static function checkedFieldProvider()
+    public static function checkedFieldProvider(): array
     {
         $cases = [
             [1, false, null, 1, false, true],
@@ -96,7 +96,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame($expected, str_contains($html, 'checked="checked"'));
     }
 
-    public static function twoPartViewValueProvider()
+    public static function twoPartViewValueProvider(): array
     {
         return [
             'object property' => [true, (object) ['flag' => 'object value'], 'object value'],
@@ -134,7 +134,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('0', $actual);
     }
 
-    public static function onePartScalarViewValueProvider()
+    public static function onePartScalarViewValueProvider(): array
     {
         return [
             ['active'],
@@ -168,7 +168,7 @@ class FormTest extends PHPUnit\Framework\TestCase
         $this->assertSame('fallback', $actual);
     }
 
-    public static function onePartNonScalarValueProvider()
+    public static function onePartNonScalarValueProvider(): array
     {
         return [
             [(object) ['value' => 'ignored']],

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -97,7 +97,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider emptySchemaInputs
+     * @dataProvider emptySchemaInputsProvider
      */
     public function testBothAdaptersDefaultNullAndEmptySchemaToPublic($schema)
     {
@@ -108,7 +108,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    public static function emptySchemaInputs(): array
+    public static function emptySchemaInputsProvider(): array
     {
         return [
             'null schema' => [null],

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -108,7 +108,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    public function emptySchemaInputs()
+    public static function emptySchemaInputs()
     {
         return [
             'null schema' => [null],

--- a/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
+++ b/core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php
@@ -108,7 +108,7 @@ class PgsqlDescribeTableTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    public static function emptySchemaInputs()
+    public static function emptySchemaInputs(): array
     {
         return [
             'null schema' => [null],


### PR DESCRIPTION
Closes #118

## Summary
- Make PHPUnit data provider methods static for PHPUnit compatibility.
- Add explicit `: array` return types to all affected providers.
- Use the `Provider` suffix consistently, including `emptySchemaInputsProvider`.

## Changes

| File | Change |
|------|--------|
| `core/tests/classes/extensions/helpers/FormTest.php` | Make four data providers static and declare `: array` return types. |
| `core/tests/classes/libs/db/adapters/PgsqlDescribeTableTest.php` | Rename `emptySchemaInputs` to `emptySchemaInputsProvider`, keeping the static `: array` signature. |

## Test Plan
- [x] Focused `FormTest.php`: 40 tests, 42 assertions passed.
- [x] Focused `PgsqlDescribeTableTest.php`: 7 tests, 22 assertions passed.
- [ ] Core PHPUnit suite: 193 tests, 333 assertions; 190 passed, 2 unrelated `ConsoleTest` failures, 1 PostgreSQL integration test skipped due to missing credentials.
- [x] PHP syntax checks with `php -l`.
- [x] `git diff --check origin/dev...HEAD`

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Focused PHPUnit tests pass
- [ ] Full core suite passes (unrelated ConsoleTest failures remain)
